### PR TITLE
Implement django-filters for filter generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,79 @@ mutation {
 }
 ```
 
+## Typed filtering with Django Filter
+
+Install django-filters `pip install django-filter`
+
+Then add `django_filters` to your INSTALLED_APPS.
+
+```python
+INSTALLED_APPS = [
+    ...
+    'django_filters',
+]
+```
+
+Write a `FilterSet` and decorate it with `strawberry_django.create_filter`:
+
+```python
+import strawberry_django
+import django_filters
+
+
+@strawberry_django.filter
+class UserFilter(django_filters.FilterSet):
+    # These fields defenitions are optional, 
+    # they can be automaticly generated.
+
+    name = django_filters.CharFilter(lookup_expr="icontains")
+    search = django_filters.CharFilter(method="filter_search")
+
+    def filter_search(self, queryset, name, value):
+        return queryset.filter(
+            Q(name__icontains=value) |
+            Q(group__name__icontains=value) |
+            Q(tag__name__icontains=value)
+        )
+
+    class Meta:
+        model = models.User
+        fields = ["name", "search"]
+```
+
+Create the input type with `UserFilter`, and filter a queryset with `strawberry_django.apply_filter`
+
+```python
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user_ids(self, filters: Optional[UserFilter] = UNSET) -> List[int]:
+        queryset = models.User.objects.all()
+        queryset = strawberry_django.apply_filter(filters, queryset)
+        return queryset.order_by("pk").values_list("pk", flat=True)
+```
+
+The schema will be:
+```
+type Query {
+  userIds(filters: UserFilter): [Int!]!
+}
+
+input UserFilter {
+  name: String
+  search: String
+}
+```
+
+And can be queried with:
+```
+query getUserIds {
+    userIds (filters: {"name": "user1", "search": "tag2"})
+}
+```
+
+See django-filter docs for details on writing FilterSets: https://django-filter.readthedocs.io
+
 ## Django authentication examples
 
 `strawberry_django` provides mutations for authentications.

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ import django_filters
 
 @strawberry_django.filter
 class UserFilter(django_filters.FilterSet):
-    # These fields defenitions are optional, 
-    # they can be automaticly generated.
+    # These fields definitions are optional, 
+    # they can be automatically generated.
 
     name = django_filters.CharFilter(lookup_expr="icontains")
     search = django_filters.CharFilter(method="filter_search")
@@ -176,7 +176,7 @@ class UserFilter(django_filters.FilterSet):
         fields = ["name", "search"]
 ```
 
-Create the input type with `UserFilter`, and filter a queryset with `strawberry_django.apply_filter`
+Create the input type with `UserFilter`, and filter a queryset with `strawberry_django.filters.apply`
 
 ```python
 @strawberry.type
@@ -184,7 +184,7 @@ class Query:
     @strawberry.field
     def user_ids(self, filters: Optional[UserFilter] = UNSET) -> List[int]:
         queryset = models.User.objects.all()
-        queryset = strawberry_django.apply_filter(filters, queryset)
+        queryset = strawberry_django.filters.apply(filters, queryset)
         return queryset.order_by("pk").values_list("pk", flat=True)
 ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -239,6 +239,20 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 testing = ["django", "django-configurations (>=2.0)"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.5.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "pytest-pythonpath"
 version = "0.7.3"
 description = "pytest plugin for adding to the PYTHONPATH from command line or configs."
@@ -389,7 +403,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "ca0b5ff3ba5aac3a3edf7fc6c0058effb242ecb929499e6691536d6e48f1cf1b"
+content-hash = "e6debd7087957da836d5e586919e4845ed85536812c978cc5960a3bcf9d56055"
 
 [metadata.files]
 asgiref = [
@@ -474,6 +488,10 @@ pytest-asyncio = [
 pytest-django = [
     {file = "pytest-django-4.1.0.tar.gz", hash = "sha256:26f02c16d36fd4c8672390deebe3413678d89f30720c16efb8b2a6bf63b9041f"},
     {file = "pytest_django-4.1.0-py3-none-any.whl", hash = "sha256:10e384e6b8912ded92db64c58be8139d9ae23fb8361e5fc139d8e4f8fc601bc2"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.5.1.tar.gz", hash = "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"},
+    {file = "pytest_mock-3.5.1-py3-none-any.whl", hash = "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e"},
 ]
 pytest-pythonpath = [
     {file = "pytest-pythonpath-0.7.3.tar.gz", hash = "sha256:63fc546ace7d2c845c1ee289e8f7a6362c2b6bae497d10c716e58e253e801d62"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -76,6 +76,17 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-filter"
+version = "2.4.0"
+description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+Django = ">=2.2"
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 description = "Pythonic argument parser, that will make you smile"
@@ -378,7 +389,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "98bb18887de50782664bae38153a01b4392c868e6a7dd9b61abc8de151bfdd12"
+content-hash = "ca0b5ff3ba5aac3a3edf7fc6c0058effb242ecb929499e6691536d6e48f1cf1b"
 
 [metadata.files]
 asgiref = [
@@ -408,6 +419,10 @@ colorama = [
 django = [
     {file = "Django-3.2-py3-none-any.whl", hash = "sha256:0604e84c4fb698a5e53e5857b5aea945b2f19a18f25f10b8748dbdf935788927"},
     {file = "Django-3.2.tar.gz", hash = "sha256:21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d"},
+]
+django-filter = [
+    {file = "django-filter-2.4.0.tar.gz", hash = "sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06"},
+    {file = "django_filter-2.4.0-py3-none-any.whl", hash = "sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1"},
 ]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pytest-django = "^4.1.0"
 pytest-pythonpath = "^0.7.3"
 pytest-watch = "^4.2.0"
 django-filter = "^2.4.0"
+pytest-mock = "^3.5.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pytest-asyncio = "^0.14.0"
 pytest-django = "^4.1.0"
 pytest-pythonpath = "^0.7.3"
 pytest-watch = "^4.2.0"
+django-filter = "^2.4.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "setuptools"]

--- a/strawberry_django/__init__.py
+++ b/strawberry_django/__init__.py
@@ -3,5 +3,6 @@ from .mutations.fields import mutations
 from .mutations.auth import AuthMutation
 from .queries.fields import queries
 from .registers import TypeRegister
+from .filters import filter, apply_filter, FilterSetError
 from .resolvers import django_resolver
 from .type import input, type

--- a/strawberry_django/__init__.py
+++ b/strawberry_django/__init__.py
@@ -3,6 +3,12 @@ from .mutations.fields import mutations
 from .mutations.auth import AuthMutation
 from .queries.fields import queries
 from .registers import TypeRegister
-from .filters import filter, apply_filter, FilterSetError
+from .filters import (
+    filter,
+    apply_filter,
+    FilterSetError,
+    get_filter_field_type,
+    set_filter_field_type,
+)
 from .resolvers import django_resolver
 from .type import input, type

--- a/strawberry_django/__init__.py
+++ b/strawberry_django/__init__.py
@@ -3,12 +3,7 @@ from .mutations.fields import mutations
 from .mutations.auth import AuthMutation
 from .queries.fields import queries
 from .registers import TypeRegister
-from .filters import (
-    filter,
-    apply_filter,
-    FilterSetError,
-    get_filter_field_type,
-    set_filter_field_type,
-)
+from . import filters
+from .filters import filter
 from .resolvers import django_resolver
 from .type import input, type

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -141,7 +141,7 @@ def filter(filterset_class: Type[django_filters.FilterSet], name=None):
     name = name or filterset_class.__name__
     cls = type(name, (), {"__annotations__": {}, "filterset_class": filterset_class})
 
-    for field_name in filterset_class.get_fields():
+    for field_name in filterset_class.get_filters().keys():
         filter_field = filters[field_name]
         field_type = get_filter_field_type(type(filter_field))
         cls.__annotations__[field_name] = field_type

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -6,11 +6,11 @@ from strawberry.arguments import UNSET, is_unset
 
 
 __all__ = [
-    "FilterSetError",
-    "apply_filter",
+    "InvalidFilterError",
+    "apply",
     "filter",
-    "get_filter_field_type",
-    "set_filter_field_type",
+    "get_field_type",
+    "set_field_type",
 ]
 
 
@@ -82,12 +82,12 @@ filter_field_type_map = {
 }
 
 
-class FilterSetError(GraphQLError):
+class InvalidFilterError(GraphQLError):
     pass
 
 
 @assert_django_filters_installed
-def get_filter_field_type(field_type):
+def get_field_type(field_type):
     if type(field_type) != type:
         raise TypeError(
             f"expected 'type', received {type(field_type)}. Maybe you forgot to call type()?"
@@ -99,7 +99,7 @@ def get_filter_field_type(field_type):
 
 
 @assert_django_filters_installed
-def set_filter_field_type(field_type, to_type):
+def set_field_type(field_type, to_type):
     if type(field_type) != type:
         raise TypeError(
             f"expected 'type', received {type(field_type)}. Maybe you forgot to call type()?"
@@ -108,7 +108,7 @@ def set_filter_field_type(field_type, to_type):
 
 
 @assert_django_filters_installed
-def apply_filter(filter_instance, queryset):
+def apply(filter_instance, queryset):
     if is_unset(filter_instance) or not filter_instance:
         return queryset
 
@@ -124,7 +124,7 @@ def apply_filter(filter_instance, queryset):
     )
 
     if not filterset.is_valid():
-        raise FilterSetError(filterset.errors)
+        raise InvalidFilterError(filterset.errors)
 
     return filterset.qs
 
@@ -143,7 +143,7 @@ def filter(filterset_class: Type[django_filters.FilterSet], name=None):
 
     for field_name in filterset_class.get_filters().keys():
         filter_field = filters[field_name]
-        field_type = get_filter_field_type(type(filter_field))
+        field_type = get_field_type(type(filter_field))
         cls.__annotations__[field_name] = field_type
         setattr(cls, field_name, UNSET)
 

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -1,0 +1,140 @@
+import functools
+from typing import Type, Optional, List
+import strawberry
+from graphql import GraphQLError
+from strawberry.arguments import UNSET, is_unset
+
+
+__all__ = [
+    "FilterSetError",
+    "apply_filter",
+    "filter",
+    "get_filter_field_type",
+    "set_filter_field_type",
+]
+
+try:
+    import django_filters
+except ModuleNotFoundError:
+    class DummyDjangoFilters:
+        def __getattribute__(self, attr):
+            return attr
+
+    django_filters = DummyDjangoFilters()
+
+
+def assert_django_filters_installed(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            import django_filters
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                'You need to install django-filter to use "strawberry_django.filter". '
+                "See https://django-filter.readthedocs.io/"
+            )
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+# TODO
+#  Some projects might want to change this to eg UUID
+#  We should make it configurable
+#  In the meantime they can overwrite "type_map" using "set_filter_field_type"
+ID_TYPE = strawberry.ID
+
+
+filter_field_type_map = {
+    django_filters.BooleanFilter: Optional[bool],
+    django_filters.CharFilter: Optional[str],
+    django_filters.ChoiceFilter: Optional[str],
+    django_filters.DateFilter: Optional[str],
+    django_filters.DateTimeFilter: Optional[str],
+    django_filters.DurationFilter: Optional[str],
+    django_filters.IsoDateTimeFilter: Optional[str],
+    django_filters.ModelChoiceFilter: Optional[ID_TYPE],
+    django_filters.ModelMultipleChoiceFilter: Optional[List[ID_TYPE]],
+    django_filters.MultipleChoiceFilter: Optional[List[str]],
+    # Use str for number fields, because it might be int, decimal or float, and casting
+    # it to any of those types might cause incorrect results for the other types.
+    django_filters.NumberFilter: Optional[str],
+    django_filters.TimeFilter: Optional[str],
+    django_filters.UUIDFilter: Optional[str],
+
+    # Not implemented because its difficult or impossible to create input types:
+    # django_filters.AllValuesFilter
+    # django_filters.AllValuesMultipleFilter
+    # django_filters.DateFromToRangeFilter
+    # django_filters.DateRangeFilter
+    # django_filters.DateTimeFromToRangeFilter
+    # django_filters.IsoDateTimeFromToRangeFilter
+    # django_filters.OrderingFilter
+    # django_filters.RangeFilter
+    # django_filters.NumericRangeFilter
+    # django_filters.TimeRangeFilter
+    # django_filters.LookupChoiceFilter
+    # django_filters.TypedChoiceFilter
+    # django_filters.TypedMultipleChoiceFilter
+}
+
+
+class FilterSetError(GraphQLError):
+    pass
+
+
+@assert_django_filters_installed
+def get_filter_field_type(field_type):
+    if type(field_type) != type:
+        raise TypeError(
+            f"expected 'type', received {type(field_type)}. Maybe you forgot to call type()?"
+        )
+    try:
+        return filter_field_type_map[field_type]
+    except KeyError:
+        raise TypeError(f"No type defined for field type '{field_type}'")
+
+
+@assert_django_filters_installed
+def set_filter_field_type(field_type, to_type):
+    if type(field_type) != type:
+        raise TypeError(
+            f"expected 'type', received {type(field_type)}. Maybe you forgot to call type()?"
+        )
+    filter_field_type_map[field_type] = to_type
+
+
+@assert_django_filters_installed
+def apply_filter(filter_instance, queryset):
+    if is_unset(filter_instance) or not filter_instance:
+        return queryset
+
+    data = {}
+    for field_name in filter_instance.filterset_class.get_fields():
+        value = getattr(filter_instance, field_name, None)
+        if not is_unset(value):
+            data[field_name] = value
+
+    filterset = filter_instance.filterset_class(
+        data=data,
+        queryset=queryset,
+    )
+
+    if not filterset.is_valid():
+        raise FilterSetError(filterset.errors)
+
+    return filterset.qs
+
+
+@assert_django_filters_installed
+def filter(filterset_class: Type[django_filters.FilterSet], name=None):
+    filters = filterset_class.get_filters()
+    name = name or filterset_class.__name__
+    cls = type(name, (), {"__annotations__": {}, "filterset_class": filterset_class})
+
+    for field_name in filterset_class.get_fields():
+        filter_field = filters[field_name]
+        field_type = get_filter_field_type(type(filter_field))
+        cls.__annotations__[field_name] = field_type
+        setattr(cls, field_name, UNSET)
+
+    return strawberry.input(cls)

--- a/tests/filters/test_filter_fields.py
+++ b/tests/filters/test_filter_fields.py
@@ -79,3 +79,12 @@ def test_should_raise_filterset_error_for_invalid_input():
     })
     with pytest.raises(strawberry_django.FilterSetError):
         strawberry_django.apply_filter(filter_instance, qs)
+
+
+def test_should_raise_when_not_extending_filterset():
+    with pytest.raises(TypeError):
+        @strawberry_django.filter
+        class Filter:
+            class Meta:
+                model = FilterModel
+                exclude = ()

--- a/tests/filters/test_filter_fields.py
+++ b/tests/filters/test_filter_fields.py
@@ -81,6 +81,22 @@ def test_should_raise_filterset_error_for_invalid_input():
         strawberry_django.apply_filter(filter_instance, qs)
 
 
+@pytest.mark.django_db
+def test_lookup_definition_in_filterset_meta():
+
+    @strawberry_django.filter
+    class LookupFilter(django_filters.FilterSet):
+        class Meta:
+            model = FilterModel
+            fields = {'char': ['iexact']}
+
+    qs = FilterModel.objects.all()
+    filter_instance = LookupFilter(**{
+        "char__iexact": "Some text",
+    })
+    strawberry_django.apply_filter(filter_instance, qs)
+
+
 def test_should_raise_when_not_extending_filterset():
     with pytest.raises(TypeError):
         @strawberry_django.filter

--- a/tests/filters/test_filter_fields.py
+++ b/tests/filters/test_filter_fields.py
@@ -50,7 +50,7 @@ def test_should_accept_string_formatted_inputs():
         "time": "00:09:00",
         "uuid": "6c9d3505-93c2-4d6c-af70-7a1b46a8bcb9",
     })
-    strawberry_django.apply_filter(filter_instance, qs)
+    strawberry_django.filters.apply(filter_instance, qs)
 
 
 @pytest.mark.django_db
@@ -66,7 +66,7 @@ def test_should_accept_native_inputs():
         "float": 1.239058,
         "integer": 5231,
     })
-    strawberry_django.apply_filter(filter_instance, qs)
+    strawberry_django.filters.apply(filter_instance, qs)
 
 
 @pytest.mark.django_db
@@ -77,8 +77,8 @@ def test_should_raise_filterset_error_for_invalid_input():
     filter_instance = Filter(**{
         "date_time": "2021-25-29T00:09:00",
     })
-    with pytest.raises(strawberry_django.FilterSetError):
-        strawberry_django.apply_filter(filter_instance, qs)
+    with pytest.raises(strawberry_django.filters.InvalidFilterError):
+        strawberry_django.filters.apply(filter_instance, qs)
 
 
 @pytest.mark.django_db
@@ -94,7 +94,7 @@ def test_lookup_definition_in_filterset_meta():
     filter_instance = LookupFilter(**{
         "char__iexact": "Some text",
     })
-    strawberry_django.apply_filter(filter_instance, qs)
+    strawberry_django.filters.apply(filter_instance, qs)
 
 
 def test_should_raise_when_not_extending_filterset():

--- a/tests/filters/test_filter_fields.py
+++ b/tests/filters/test_filter_fields.py
@@ -1,0 +1,81 @@
+import pytest
+import strawberry_django
+from django.db import models
+import django_filters
+
+
+class Related(models.Model):
+    pass
+
+
+class FilterModel(models.Model):
+    reverse_related = models.ForeignKey(Related, on_delete=models.CASCADE)
+    one_related = models.OneToOneField(Related, on_delete=models.CASCADE)
+    many_related = models.ManyToManyField(Related)
+    boolean = models.BooleanField()
+    char = models.CharField(max_length=50)
+    date = models.DateField()
+    date_time = models.DateTimeField()
+    decimal = models.DecimalField(decimal_places=2)
+    float = models.FloatField()
+    integer = models.IntegerField()
+    time = models.TimeField()
+    uuid = models.UUIDField()
+
+
+@strawberry_django.filter
+class Filter(django_filters.FilterSet):
+    class Meta:
+        model = FilterModel
+        exclude = ()
+
+
+@pytest.mark.django_db
+def test_should_accept_string_formatted_inputs():
+    qs = FilterModel.objects.all()
+    related = Related.objects.create()
+
+    # Should accept string formatted inputs
+    filter_instance = Filter(**{
+        "reverse_related": f"{related.pk}",
+        "one_related": f"{related.pk}",
+        "many_related": [related.pk],
+        "boolean": "true",
+        "char": "Some Text",
+        "date": "2021-01-01",
+        "date_time": "2021-01-01T00:09:00",
+        "decimal": "1.01",
+        "float": "1.239058",
+        "integer": "5231",
+        "time": "00:09:00",
+        "uuid": "6c9d3505-93c2-4d6c-af70-7a1b46a8bcb9",
+    })
+    strawberry_django.apply_filter(filter_instance, qs)
+
+
+@pytest.mark.django_db
+def test_should_accept_native_inputs():
+    qs = FilterModel.objects.all()
+    related = Related.objects.create()
+
+    filter_instance = Filter(**{
+        "reverse_related": related.pk,
+        "one_related": related.pk,
+        "boolean": True,
+        "decimal": 1.01,
+        "float": 1.239058,
+        "integer": 5231,
+    })
+    strawberry_django.apply_filter(filter_instance, qs)
+
+
+@pytest.mark.django_db
+def test_should_raise_filterset_error_for_invalid_input():
+    qs = FilterModel.objects.all()
+
+    # Should raise for invalid field
+    filter_instance = Filter(**{
+        "date_time": "2021-25-29T00:09:00",
+    })
+    with pytest.raises(strawberry_django.FilterSetError):
+        strawberry_django.apply_filter(filter_instance, qs)

--- a/tests/filters/test_filter_import.py
+++ b/tests/filters/test_filter_import.py
@@ -1,0 +1,28 @@
+import pytest
+import strawberry_django
+from strawberry_django.filters import DummyDjangoFilters
+
+
+@pytest.fixture
+def django_filters_mock(mocker):
+    return mocker.patch('strawberry_django.filters.django_filters', DummyDjangoFilters())
+
+
+def test_filter_with_dummy_filters_raises_error(django_filters_mock):
+    with pytest.raises(ModuleNotFoundError):
+        strawberry_django.filter()
+
+
+def test_apply_filter_with_dummy_filters_raises_error(django_filters_mock):
+    with pytest.raises(ModuleNotFoundError):
+        strawberry_django.apply_filter()
+
+
+def test_get_filter_field_type_with_dummy_filters_raises_error(django_filters_mock):
+    with pytest.raises(ModuleNotFoundError):
+        strawberry_django.get_filter_field_type()
+
+
+def test_set_filter_field_type_with_dummy_filters_raises_error(django_filters_mock):
+    with pytest.raises(ModuleNotFoundError):
+        strawberry_django.set_filter_field_type()

--- a/tests/filters/test_filter_import.py
+++ b/tests/filters/test_filter_import.py
@@ -15,14 +15,14 @@ def test_filter_with_dummy_filters_raises_error(django_filters_mock):
 
 def test_apply_filter_with_dummy_filters_raises_error(django_filters_mock):
     with pytest.raises(ModuleNotFoundError):
-        strawberry_django.apply_filter()
+        strawberry_django.filters.apply()
 
 
-def test_get_filter_field_type_with_dummy_filters_raises_error(django_filters_mock):
+def test_get_field_type_with_dummy_filters_raises_error(django_filters_mock):
     with pytest.raises(ModuleNotFoundError):
-        strawberry_django.get_filter_field_type()
+        strawberry_django.filters.get_field_type()
 
 
-def test_set_filter_field_type_with_dummy_filters_raises_error(django_filters_mock):
+def test_set_field_type_with_dummy_filters_raises_error(django_filters_mock):
     with pytest.raises(ModuleNotFoundError):
-        strawberry_django.set_filter_field_type()
+        strawberry_django.filters.set_field_type()

--- a/tests/filters/test_filter_query.py
+++ b/tests/filters/test_filter_query.py
@@ -1,0 +1,107 @@
+from typing import List, Optional
+
+import pytest
+import strawberry
+import strawberry_django
+from django.db.models import Q
+from strawberry.arguments import UNSET
+import django_filters
+from tests import models
+
+
+@pytest.fixture
+def execute():
+    group1 = models.Group.objects.create(name="group1")
+    tag1 = models.Tag.objects.create(name="tag1")
+    tag2 = models.Tag.objects.create(name="tag2")
+    models.User.objects.create(name="user1", group=group1, tag=tag1)
+    models.User.objects.create(name="user2", tag=tag2)
+    models.User.objects.create(name="user3")
+
+    @strawberry_django.filter
+    class UserFilter(django_filters.FilterSet):
+        name = django_filters.CharFilter(lookup_expr="icontains")
+        search = django_filters.CharFilter(method="filter_search")
+
+        def filter_search(self, queryset, name, value):
+            return queryset.filter(
+                Q(name__icontains=value) |
+                Q(group__name__icontains=value) |
+                Q(tag__name__icontains=value)
+            )
+
+        class Meta:
+            model = models.User
+            fields = ["name", "search"]
+
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def user_ids(self, filters: Optional[UserFilter] = UNSET) -> List[int]:
+            queryset = models.User.objects.all()
+            queryset = strawberry_django.apply_filter(filters, queryset)
+            return queryset.order_by("pk").values_list("pk", flat=True)
+
+    schema = strawberry.Schema(query=Query)
+    query = """
+        query getUserIds ($filters: UserFilter) {
+            userIds (filters: $filters)
+        }
+    """
+
+    def execute(variable_values):
+        return schema.execute_sync(query, variable_values=variable_values)
+
+    return execute
+
+
+@pytest.mark.django_db
+def test_passing_no_filter(execute):
+    variable_values = {}
+    result = execute(variable_values)
+    assert result.data
+    assert result.data["userIds"] == [1, 2, 3]
+    assert result.errors == None
+
+
+@pytest.mark.django_db
+def test_passing_empty_filter(execute):
+    variable_values = {"filters": {}}
+    result = execute(variable_values)
+    assert result.data
+    assert result.data.get("userIds", None) == [1, 2, 3]
+    assert result.errors == None
+
+
+@pytest.mark.django_db
+def test_passing_none_filter(execute):
+    variable_values = {"filters": None}
+    result = execute(variable_values)
+    assert result.data
+    assert result.data.get("userIds", None) == [1, 2, 3]
+    assert result.errors == None
+
+
+@pytest.mark.django_db
+def test_lookup_char_filter(execute):
+    variable_values = {"filters": {"name": "user1"}}
+    result = execute(variable_values)
+    assert result.data
+    assert result.data.get("userIds", None) == [1]
+    assert result.errors == None
+
+
+@pytest.mark.django_db
+def test_custom_char_filter(execute):
+    variable_values = {"filters": {"search": "tag2"}}
+    result = execute(variable_values)
+    assert result.data
+    assert result.data.get("userIds", None) == [2]
+    assert result.errors == None
+
+    variable_values = {"filters": {"search": "group1"}}
+    result = execute(variable_values)
+    assert result.data
+    assert result.data.get("userIds", None) == [1]
+    assert result.errors == None

--- a/tests/filters/test_filter_query.py
+++ b/tests/filters/test_filter_query.py
@@ -40,7 +40,7 @@ def execute():
         @strawberry.field
         def user_ids(self, filters: Optional[UserFilter] = UNSET) -> List[int]:
             queryset = models.User.objects.all()
-            queryset = strawberry_django.apply_filter(filters, queryset)
+            queryset = strawberry_django.filters.apply(filters, queryset)
             return queryset.order_by("pk").values_list("pk", flat=True)
 
     schema = strawberry.Schema(query=Query)


### PR DESCRIPTION
Some things to consider:

- Should we make "django-filters" an optional dependency?
- How do we implement this into the library? I suppose it should be optional, and easy to modify.
We could add global settings eg:
```
STRAWBERRY_DJANGO_GENERATE_FILTERS = "default to false, when set true we raise error when its not installed"
STRAWBERRY_DJANGO_FILTER_FACTORY = "defaults_to_django-filters_factory_fn"
```
And also allow for overwriting it in specific queries. 
