### PR TITLE
Bug: excluding foreignkey in input sets it to None

### DIFF
--- a/tests/mutations/test_relations.py
+++ b/tests/mutations/test_relations.py
@@ -23,6 +23,11 @@ def test_update_foreign_key(mutation, user, group):
     user = models.User.objects.get()
     assert user.group == group
 
+    result = mutation('{ updateUsers(data: { name: "newName" }) { id } }')
+    assert not result.errors
+    user = models.User.objects.get()
+    assert user.group == group
+
     result = mutation('{ updateUsers(data: { groupId: null }) { id } }')
     assert not result.errors
     user = models.User.objects.get()


### PR DESCRIPTION
This test case fails, because `data.groupId` will be `None` instead of `Unset`