### PR TITLE
Deprecate is_update parameter

### DIFF
--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 import strawberry
 from .. import fields, hooks, utils
-from ..type import generate_update_from_input
+from ..type import generate_partial_input
 from ..queries.arguments import resolve_type_args
 from ..resolvers import django_resolver
 
@@ -44,7 +44,7 @@ def create_batch(*args, types=None, pre_save=None, post_save=None):
 
 def update(*args, types=None):
     model, output_type, input_type = resolve_type_args(args, types=types, is_input=True, single=True)
-    update_type = generate_update_from_input(model, input_type)
+    update_type = generate_partial_input(model, input_type)
     @strawberry.mutation
     @django_resolver
     def mutation(data: update_type, filters: Optional[List[str]] = []) -> List[output_type]:

--- a/strawberry_django/types.py
+++ b/strawberry_django/types.py
@@ -91,10 +91,10 @@ def get_field_type(field, type_register, is_input):
     raise TypeError(f"No type defined for '{db_field_type.__name__}'")
 
 
-def is_optional(field, is_input, is_update):
+def is_optional(field, is_input, partial):
     if is_input:
         has_default = field.default != fields.NOT_PROVIDED
-        if field.blank or is_update or has_default:
+        if field.blank or partial or has_default:
             return True
     if field.null:
         return True
@@ -125,7 +125,7 @@ def process_fields(fields, model):
     return field_names
 
 
-def get_model_fields(cls, model, fields, types, is_input, is_update):
+def get_model_fields(cls, model, fields, types, is_input, partial):
     if fields == []:
         return []
 
@@ -153,7 +153,7 @@ def get_model_fields(cls, model, fields, types, is_input, is_update):
                 else:
                     field_name = field.attname
                     field_type = strawberry.ID
-                    if is_optional(field, is_input, is_update):
+                    if is_optional(field, is_input, partial):
                         field_type = Optional[field_type]
                     model_fields.append((field_name, field_type, strawberry.arguments.UNSET))
                 continue
@@ -172,7 +172,7 @@ def get_model_fields(cls, model, fields, types, is_input, is_update):
         else:
             field_value = strawberry.arguments.UNSET
 
-        if is_optional(field, is_input, is_update):
+        if is_optional(field, is_input, partial):
             field_type = Optional[field_type]
 
         model_fields.append((field.name, field_type, field_value))

--- a/strawberry_django/utils.py
+++ b/strawberry_django/utils.py
@@ -2,6 +2,7 @@ import strawberry
 from django.db.models import fields
 import ast
 import asyncio
+import warnings
 
 def parse_value(value):
     try:
@@ -62,3 +63,7 @@ def is_async():
         if event_loop.is_running():
             return True
     return False
+
+
+def deprecated(msg, stacklevel=1):
+    warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel + 1)

--- a/tests/fields/test_input.py
+++ b/tests/fields/test_input.py
@@ -27,7 +27,7 @@ def test_input_type():
 
 
 def test_input_type_for_partial_update():
-    @strawberry_django.input(InputFieldsModel, is_update=True)
+    @strawberry_django.input(InputFieldsModel, partial=True)
     class InputType:
         pass
 


### PR DESCRIPTION
We are planning to deprecate `is_update` parameter and introduce new `partial` parameter of `strawberry_django.input`. `is_update` will be removed in v0.2 version.