### PR TITLE
Removes pk argument on model relations

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -143,9 +143,10 @@ class StrawberryDjangoFieldFilters:
         if not self.base_resolver:
             filters = self.get_filters()
             if self.django_model and not self.is_list:
-                arguments.append(
-                    argument('pk', strawberry.ID)
-                )
+                if self.is_relation is False:
+                    arguments.append(
+                        argument('pk', strawberry.ID)
+                    )
             elif filters and not is_unset(filters):
                 arguments.append(
                     argument('filters', filters)


### PR DESCRIPTION
Test schema becomes:

```
type BerryFruit {
  id: ID!
  name: String!
  nameUpper: String!
  nameLower: String!
}

type Group {
  id: ID!
  name: String!
  users: [User!]
}

type Query {
  user(pk: ID): User!
  users: [User!]!
  group(pk: ID): Group!
  groups: [Group!]!
  berries: [BerryFruit!]!
}

type User {
  id: ID!
  name: String!
  group: Group
}
```