### PR TITLE
Fix filtering in `get_queryset` of types with enabled pagination

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -15,11 +15,6 @@ from ..resolvers import django_resolver
 
 class StrawberryDjangoFieldBase:
     def get_queryset(self, queryset, info, **kwargs):
-        type_ = self.type or self.child.type
-        type_ = utils.unwrap_type(type_)
-        get_queryset = getattr(type_, 'get_queryset', None)
-        if get_queryset:
-            queryset = get_queryset(self, queryset, info, **kwargs)
         return queryset
 
     @property
@@ -125,6 +120,14 @@ class StrawberryDjangoField(
                 result = result.get()
 
         return result
+
+    def get_queryset(self, queryset, info, order=UNSET, **kwargs):
+        type_ = self.type or self.child.type
+        type_ = utils.unwrap_type(type_)
+        get_queryset = getattr(type_, 'get_queryset', None)
+        if get_queryset:
+            queryset = get_queryset(self, queryset, info, **kwargs)
+        return super().get_queryset(queryset, info, order, **kwargs)
 
 
 def field(resolver=None, *, name=None, field_name=None, filters=UNSET, default=UNSET, **kwargs):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -10,9 +10,18 @@ from tests import utils, models
 class Fruit:
     name: auto
 
+@strawberry_django.type(models.Fruit, pagination=True)
+class BerryFruit:
+    name: auto
+
+    def get_queryset(self, queryset, info, **kwargs):
+        return queryset.filter(name__contains='berry')
+
+
 @strawberry.type
 class Query:
     fruits: List[Fruit] = strawberry_django.field()
+    berries: List[BerryFruit] = strawberry_django.field()
 
 @pytest.fixture
 def query():
@@ -23,5 +32,12 @@ def test_pagination(query, fruits):
     result = query('{ fruits(pagination: { offset: 1, limit:1 }) { name } }')
     assert not result.errors
     assert result.data['fruits'] == [
+        { 'name': 'raspberry'},
+    ]
+
+def test_pagination_of_filtered_query(query, fruits):
+    result = query('{ berries(pagination: { offset: 1, limit:1 }) { name } }')
+    assert not result.errors
+    assert result.data['berries'] == [
         { 'name': 'raspberry'},
     ]


### PR DESCRIPTION
`get_queryset` of types used to be called with a query set that had already been processed by `StrawberryDjangoFieldOrdering.get_queryset`, `StrawberryDjangoFieldFilters.get_queryset`, and `StrawberryDjangoPagination.get_queryset`.

When pagination was enabled, it was not possible to filter a query set because `Cannot filter a query once a slice has been taken.`

This changes the order so that `get_queryset` of types is called in the beginning.

Fixes #55.