### PR TITLE
Fix a bug related to creating users with unhashed passwords

### DIFF
--- a/strawberry_django/auth/mutations.py
+++ b/strawberry_django/auth/mutations.py
@@ -2,7 +2,7 @@ from django.contrib import auth
 from django.contrib.auth.password_validation import validate_password
 import strawberry
 
-from strawberry_django.mutations.fields import get_input_data
+from strawberry_django.mutations.fields import get_input_data, update_m2m
 from strawberry_django.mutations.fields import DjangoCreateMutation
 
 from ..resolvers import django_resolver
@@ -45,5 +45,6 @@ class DjangoRegisterMutation(DjangoCreateMutation):
     def create(self, data):
         input_data = get_input_data(self.input_type, data)
         validate_password(input_data["password"])
-
-        return super().create(data)
+        instance = self.django_model.objects.create_user(**input_data)
+        update_m2m([instance], data)
+        return instance

--- a/tests/auth/test_mutations.py
+++ b/tests/auth/test_mutations.py
@@ -98,15 +98,18 @@ def test_logout_without_logged_in(mutation, user, context):
 
 
 def test_register_new_user(mutation, user, context):
+    password = "test_password"
     result = mutation(
-        '{ register(data: {username: "new_user", password: "test_password"}) { username } }',
+        '{ register(data: {username: "new_user", password: "%s"}) { username } }' % password,
         context_value=context,
     )
 
     assert not result.errors
     assert result.data["register"] == {"username": "new_user"}
 
-    assert UserModel.objects.get(username="new_user")
+    user = UserModel.objects.get(username="new_user")
+    assert user.id
+    assert user.check_password(password)
 
 def test_register_with_invalid_password(mutation, user, context):
     result = mutation(


### PR DESCRIPTION
This fixes the security flaw of #45 where `auth.register` saves unhashed passwords.