### PR TITLE
Fix detecting `auto` annotations when postponed evaluation is used

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -166,9 +166,13 @@ def get_model_field(model, field_name):
 
 
 def is_auto(type_):
-    return (
-        type_.annotation if isinstance(type_, StrawberryAnnotation) else type_
-    ) is auto
+    if not isinstance(type_, StrawberryAnnotation):
+        return type_ is auto
+    annotation = type_.annotation
+    if isinstance(annotation, str):
+        namespace = type_.namespace
+        return namespace and namespace.get(annotation) is auto
+    return annotation is auto
 
 
 def is_optional(model_field, is_input, partial):

--- a/strawberry_django/utils.py
+++ b/strawberry_django/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import sys
 import warnings
 
 from django.db import models
@@ -87,10 +88,14 @@ def is_similar_django_type(a, b):
 
 def get_annotations(cls):
     annotations = {}
+    namespace = sys.modules[cls.__module__].__dict__
     for c in reversed(cls.__mro__):
         if "__annotations__" in c.__dict__:
             annotations.update(
-                {k: StrawberryAnnotation(v) for k, v in c.__annotations__.items()}
+                {
+                    k: StrawberryAnnotation(v, namespace=namespace)
+                    for k, v in c.__annotations__.items()
+                }
             )
     return annotations
 

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -8,11 +8,12 @@ import django
 import pytest
 import strawberry
 from django.db import models
+from strawberry.annotation import StrawberryAnnotation
 from strawberry.enum import EnumDefinition, EnumValue
 from strawberry.type import StrawberryList, StrawberryOptional
 
 import strawberry_django
-from strawberry_django import auto, fields
+from strawberry_django import auto, fields, is_auto
 
 
 class FieldTypesModel(models.Model):
@@ -354,3 +355,33 @@ def test_type_from_type():
             StrawberryOptional(strawberry_django.ManyToManyInput),
         ),
     ]
+
+
+def test_is_auto_passing_auto():
+    assert is_auto(auto)
+
+
+def test_is_auto_passing_non_auto():
+    assert not is_auto(int)
+
+
+def test_is_auto_passing_auto_strawberry_annotation():
+    assert is_auto(StrawberryAnnotation(auto))
+
+
+def test_is_auto_passing_non_auto_strawberry_annotation():
+    assert not is_auto(StrawberryAnnotation(int))
+
+
+def test_is_auto_passing_auto_as_str_strawberry_annotation():
+    assert is_auto(StrawberryAnnotation("auto", namespace={"auto": auto}))
+
+
+def test_is_auto_passing_aliased_auto_as_str_strawberry_annotation():
+    assert is_auto(
+        StrawberryAnnotation("aliased_auto", namespace={"aliased_auto": auto})
+    )
+
+
+def test_is_auto_passing_non_auto_as_str_strawberry_annotation():
+    assert not is_auto(StrawberryAnnotation("SomeType", namespace={"SomeType": type}))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,6 +15,17 @@ def test_type_instance():
     assert user.name == "user"
 
 
+def test_type_instance_auto_as_str():
+    @strawberry_django.type(User)
+    class UserType:
+        id: "auto"
+        name: "auto"
+
+    user = UserType(1, "user")
+    assert user.id == 1
+    assert user.name == "user"
+
+
 def test_input_instance():
     @strawberry_django.input(User)
     class InputType:

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 import strawberry_django


### PR DESCRIPTION
Previously, when `from __future__ import annotations` was added to a file defining fields with the `auto` annotation, resolving failed because of `TypeError: {Type} fields cannot be resolved. Unexpected type '<class 'strawberry_django.fields.types.auto'>'`.

This PR updates the `is_auto` function to detect such annotations.

Fixes #52.