### PR TITLE
Fixed issue with generating order args

### DIFF
--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -27,8 +27,7 @@ def generate_order_args(order, prefix=""):
         elif ordering == Ordering.DESC:
             args.append(f"-{prefix}{field.name}")
         else:
-            prefix = f"{prefix}{field.name}__"
-            subargs = generate_order_args(ordering, prefix=prefix)
+            subargs = generate_order_args(ordering, prefix=f"{prefix}{field.name}__")
             args.extend(subargs)
     return args
 


### PR DESCRIPTION
In this example, the `supplier__name` order arg was generated first, and the subsequent `name` arg was also prefixed with `supplier__`.

```graphql
query {
  inventoryItems(order: {
    supplier: {
      name: ASC
    },
    name: ASC
  }) {
    name
    supplier {
      name
    }
  }
}
