### PR TITLE
feat: add Enum support to filtering

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Generic, List, Optional, TypeVar
 
 import strawberry
@@ -81,6 +82,9 @@ def build_filter_kwargs(filters):
 
         if is_unset(field_value):
             continue
+
+        if isinstance(field_value, Enum):
+            field_value = field_value.value
 
         filter_method = getattr(filters, f"filter_{field_name}", None)
         if filter_method:

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -165,7 +165,7 @@ def test_resolver_filter(fruits):
 
 
 def test_enum(query, fruits):
-    result = query('{ fruits: enumFilter(filters: { name: strawberry }) { id name } }')
+    result = query("{ fruits: enumFilter(filters: { name: strawberry }) { id name } }")
     assert not result.errors
     assert result.data["fruits"] == [
         {"id": "1", "name": "strawberry"},


### PR DESCRIPTION
Often in Django you will add `ChoiceField` to a model. With Django >= 3.0, you can now build enums that work for choices (https://docs.djangoproject.com/en/3.2/ref/models/fields/#enumeration-types). Using this, we can use the same Choices to build Strawberry Enums to use for filters.

For example, you can now:
```python
class ColorChoices(TextChoices):
    blue = "BLUE"
    red = "RED"

class Bags(models.Model):
    color = models.ChoiceField(TextChoices)

@strawberry.enum
class ColorEnum(ColorChoices):
    ...

@strawberry_django.filters.filter(Bags)
class BagFilter:
    color: ColorEnum
```

This will allow the GraphQL to expose the Enum options and enable filtering using that Enum.

Prior to this, a user would have to define the enum filter method explicitly using:
```python
@strawberry_django.filters.filter(Bags)
class BagFilter:
    color: ColorEnum

    def filter_color(self, queryset):
         return queryset.filter(color=self.color.value)
```
