### PR TITLE
Use auto from strawberry instead of define our own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,8 @@ This release adds new class oriented API where all fields are defined in class b
 Example above shows how the new API looks like.
 
 ```python
+from strawberry import auto
 import strawberry_django
-from strawberry_django import auto
 from . import models
 
 @strawberry_django.type(models.Color)

--- a/README.md
+++ b/README.md
@@ -7,22 +7,21 @@
 This package provides powerful tools to generate GraphQL types, queries, mutations and resolvers from Django models.
 
 Installing `strawberry-graphql-django` package from the python package repository.
+
 ```shell
 pip install strawberry-graphql-django
 ```
 
 Full documentation is available under [docs](https://github.com/strawberry-graphql/strawberry-graphql-django/tree/main/docs/index.md) github folder.
 
-
 ## Supported features
 
-* GraphQL type generation from models
-* Filtering, pagination and ordering
-* Basic create, retrieve, update and delete (CRUD) types and mutations
-* Basic Django auth support, current user query, login and logout mutations
-* Django sync and async views
-* Unit test integration
-
+- GraphQL type generation from models
+- Filtering, pagination and ordering
+- Basic create, retrieve, update and delete (CRUD) types and mutations
+- Basic Django auth support, current user query, login and logout mutations
+- Django sync and async views
+- Unit test integration
 
 ## Basic Usage
 
@@ -42,7 +41,7 @@ class Color(models.Model):
 ```python
 # types.py
 import strawberry
-from strawberry.django import auto
+from strawberry import auto
 from typing import List
 from . import models
 
@@ -104,7 +103,6 @@ urlpatterns = [
 ```
 
 See complete Django project from github repository folder [examples/django](https://github.com/strawberry-graphql/strawberry-graphql-django/tree/main/examples/django).
-
 
 ## Autocompletion with editors
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -97,7 +97,7 @@ We also need to add another type and modify existing one. Field type `auto` is u
 ```python
 # types.py
 import strawberry_django
-from strawberry_django import auto
+from strawberry import auto
 from typing import List
 from . import models
 

--- a/docs/references/authentication.md
+++ b/docs/references/authentication.md
@@ -7,7 +7,7 @@ validate_password().
 ```python
 # types.py
 import strawberry
-from strawberry.django import auto
+from strawberry import auto
 from django.contrib.auth import get_user_model
 
 @strawberry.django.type(get_user_model())

--- a/docs/references/fields.md
+++ b/docs/references/fields.md
@@ -6,7 +6,7 @@ Fields can be defined manually or `auto` type can be used for automatic type res
 #types.py
 
 import strawberry
-from strawberry.django import auto
+from strawberry import auto
 
 @strawberry.django.type(models.Fruit)
 class Fruit:

--- a/docs/references/filters.md
+++ b/docs/references/filters.md
@@ -2,7 +2,7 @@
 
 ```python
 import strawberry
-from strawberry.django import auto
+from strawberry import auto
 
 @strawberry.django.filters.filter(models.Fruit)
 class FruitFilter:

--- a/docs/references/resolvers.md
+++ b/docs/references/resolvers.md
@@ -9,7 +9,7 @@ However it is possible to overwrite them by writing own resolvers.
 ```python
 # types.py
 
-from strawberry.django import auto
+from strawberry import auto
 from typing import List
 from . import models
 
@@ -28,7 +28,7 @@ class Color:
 ```python
 # types.py
 
-from strawberry.django import auto
+from strawberry import auto
 from typing import List
 from . import models
 from asgiref.sync import sync_to_async

--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -5,7 +5,7 @@
 Output types are generated from models. `auto` type is used for field type auto resolution. Relational fields are described by referencing to other type genedated from Django model. Many to many relation is described by using List type. `strawberry.django` will automatically generate resolvers for relational fields. More information about that can be read from [resolvers](resolvers.md) page.
 
 ```python
-from strawberry.django import auto
+from strawberry import auto
 from typing import List
 
 @strawberry.django.type(models.Fruit)

--- a/examples/django/app/types.py
+++ b/examples/django/app/types.py
@@ -1,9 +1,9 @@
 from typing import List
 
 from django.contrib.auth import get_user_model
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto
 
 from . import models
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "asgiref"
-version = "3.5.0"
+version = "3.5.2"
 description = "ASGI specs, helper code, and adapters"
 category = "main"
 optional = false
@@ -44,11 +44,11 @@ python-versions = ">=3.6.0"
 
 [[package]]
 name = "click"
-version = "8.0.4"
+version = "8.1.3"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -64,7 +64,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "django"
-version = "3.2.12"
+version = "3.2.13"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
@@ -100,7 +100,7 @@ python-versions = "*"
 
 [[package]]
 name = "graphql-core"
-version = "3.2.0"
+version = "3.2.1"
 description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
 category = "main"
 optional = false
@@ -108,7 +108,7 @@ python-versions = ">=3.6,<4"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.2"
+version = "4.11.4"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -167,30 +167,30 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pygments"
-version = "2.11.2"
+version = "2.12.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.7"
-description = "Python parsing module"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pytest"
-version = "6.2.5"
+version = "7.1.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
@@ -201,24 +201,25 @@ iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
-toml = "*"
+tomli = ">=1.0.0"
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.14.0"
-description = "Pytest support for asyncio."
+version = "0.18.3"
+description = "Pytest support for asyncio"
 category = "dev"
 optional = false
-python-versions = ">= 3.5"
+python-versions = ">=3.7"
 
 [package.dependencies]
-pytest = ">=5.4.0"
+pytest = ">=6.1.0"
+typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["async-generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
+testing = ["coverage (==6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (==0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "pytest-django"
@@ -251,14 +252,14 @@ dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 name = "pytest-pythonpath"
-version = "0.7.4"
+version = "0.7.3"
 description = "pytest plugin for adding to the PYTHONPATH from command line or configs."
 category = "dev"
 optional = false
-python-versions = ">=2.6, <4"
+python-versions = "*"
 
 [package.dependencies]
-pytest = ">=2.5.2,<7"
+pytest = ">=2.5.2"
 
 [[package]]
 name = "pytest-watch"
@@ -298,7 +299,7 @@ six = ">=1.4.0"
 
 [[package]]
 name = "pytz"
-version = "2021.3"
+version = "2022.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -322,7 +323,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.101.0"
+version = "0.113.0"
 description = "A library for creating GraphQL APIs"
 category = "main"
 optional = false
@@ -338,9 +339,9 @@ python-multipart = ">=0.0.5,<0.0.6"
 typing_extensions = ">=3.7.4,<5.0.0"
 
 [package.extras]
-asgi = ["starlette (>=0.13.6,<0.17.0)"]
-debug-server = ["starlette (>=0.13.6,<0.17.0)", "uvicorn (>=0.11.6,<0.18.0)"]
-django = ["Django (>=2.2)", "asgiref (>=3.2,<4.0)"]
+asgi = ["starlette (>=0.13.6)"]
+debug-server = ["starlette (>=0.13.6)", "uvicorn (>=0.11.6,<0.18.0)"]
+django = ["Django (>=3.2)", "asgiref (>=3.2,<4.0)"]
 flask = ["flask (>=1.1)"]
 opentelemetry = ["opentelemetry-api (<2)", "opentelemetry-sdk (<2)"]
 chalice = ["chalice (>=1.22,<2.0)"]
@@ -350,24 +351,24 @@ aiohttp = ["aiohttp (>=3.7.4.post0,<4.0.0)"]
 fastapi = ["fastapi (>=0.65.2)"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
 category = "dev"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.7"
 
 [[package]]
 name = "typing-extensions"
-version = "4.1.1"
-description = "Backported and Experimental Type Hints for Python 3.6+"
+version = "4.2.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "watchdog"
-version = "2.1.6"
+version = "2.1.8"
 description = "Filesystem events monitoring"
 category = "dev"
 optional = false
@@ -378,25 +379,25 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "zipp"
-version = "3.7.0"
+version = "3.8.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "c730e91a5e9057302ca5a1fcd0f7e06cefa21653daeaae0fe2f416f0cd45a776"
+content-hash = "b8df671e493f4a85fe4b3d5753a4f6429840eee20186cc69024d5fb2eda3095e"
 
 [metadata.files]
 asgiref = [
-    {file = "asgiref-3.5.0-py3-none-any.whl", hash = "sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9"},
-    {file = "asgiref-3.5.0.tar.gz", hash = "sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0"},
+    {file = "asgiref-3.5.2-py3-none-any.whl", hash = "sha256:1d2880b792ae8757289136f1db2b7b99100ce959b2aa57fd69dab783d05afac4"},
+    {file = "asgiref-3.5.2.tar.gz", hash = "sha256:4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -411,16 +412,16 @@ attrs = [
     {file = "backports.cached_property-1.0.1-py3-none-any.whl", hash = "sha256:687b5fe14be40aadcf547cae91337a1fdb84026046a39370274e54d3fe4fb4f9"},
 ]
 click = [
-    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
-    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 django = [
-    {file = "Django-3.2.12-py3-none-any.whl", hash = "sha256:9b06c289f9ba3a8abea16c9c9505f25107809fb933676f6c891ded270039d965"},
-    {file = "Django-3.2.12.tar.gz", hash = "sha256:9772e6935703e59e993960832d66a614cf0233a1c5123bc6224ecc6ad69e41e2"},
+    {file = "Django-3.2.13-py3-none-any.whl", hash = "sha256:b896ca61edc079eb6bbaa15cf6071eb69d6aac08cce5211583cfb41515644fdf"},
+    {file = "Django-3.2.13.tar.gz", hash = "sha256:6d93497a0a9bf6ba0e0b1a29cccdc40efbfc76297255b1309b3a884a688ec4b6"},
 ]
 django-filter = [
     {file = "django-filter-2.4.0.tar.gz", hash = "sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06"},
@@ -430,12 +431,12 @@ docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
 graphql-core = [
-    {file = "graphql-core-3.2.0.tar.gz", hash = "sha256:86e2a0be008bfde19ef78388de8a725a1d942a9190ca431c24a60837973803ce"},
-    {file = "graphql_core-3.2.0-py3-none-any.whl", hash = "sha256:0dda7e63676f119bb3d814621190fedad72fda07a8e9ab780bedd9f1957c6dc6"},
+    {file = "graphql-core-3.2.1.tar.gz", hash = "sha256:9d1bf141427b7d54be944587c8349df791ce60ade2e3cccaf9c56368c133c201"},
+    {file = "graphql_core-3.2.1-py3-none-any.whl", hash = "sha256:f83c658e4968998eed1923a2e3e3eddd347e005ac0315fbb7ca4d70ea9156323"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
-    {file = "importlib_metadata-4.11.2.tar.gz", hash = "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac"},
+    {file = "importlib_metadata-4.11.4-py3-none-any.whl", hash = "sha256:c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec"},
+    {file = "importlib_metadata-4.11.4.tar.gz", hash = "sha256:5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -454,20 +455,21 @@ py = [
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pygments = [
-    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
-    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
+    {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
+    {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
-    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytest = [
-    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
-    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
+    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
 ]
 pytest-asyncio = [
-    {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
-    {file = "pytest_asyncio-0.14.0-py3-none-any.whl", hash = "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d"},
+    {file = "pytest-asyncio-0.18.3.tar.gz", hash = "sha256:7659bdb0a9eb9c6e3ef992eef11a2b3e69697800ad02fb06374a210d85b29f91"},
+    {file = "pytest_asyncio-0.18.3-1-py3-none-any.whl", hash = "sha256:16cf40bdf2b4fb7fc8e4b82bd05ce3fbcd454cbf7b92afc445fe299dabb88213"},
+    {file = "pytest_asyncio-0.18.3-py3-none-any.whl", hash = "sha256:8fafa6c52161addfd41ee7ab35f11836c5a16ec208f93ee388f752bea3493a84"},
 ]
 pytest-django = [
     {file = "pytest-django-4.5.2.tar.gz", hash = "sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2"},
@@ -478,8 +480,7 @@ pytest-mock = [
     {file = "pytest_mock-3.7.0-py3-none-any.whl", hash = "sha256:6cff27cec936bf81dc5ee87f07132b807bcda51106b5ec4b90a04331cba76231"},
 ]
 pytest-pythonpath = [
-    {file = "pytest-pythonpath-0.7.4.tar.gz", hash = "sha256:64e195b23a8f8c0c631fb16882d9ad6fa4137ed1f2961ddd15d52065cd435db6"},
-    {file = "pytest_pythonpath-0.7.4-py3-none-any.whl", hash = "sha256:e73e11dab2f0b83e73229e261242b251f0a369d7f527dbfec068822fd26a6ce5"},
+    {file = "pytest-pythonpath-0.7.3.tar.gz", hash = "sha256:63fc546ace7d2c845c1ee289e8f7a6362c2b6bae497d10c716e58e253e801d62"},
 ]
 pytest-watch = [
     {file = "pytest-watch-4.2.0.tar.gz", hash = "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9"},
@@ -492,8 +493,8 @@ python-multipart = [
     {file = "python-multipart-0.0.5.tar.gz", hash = "sha256:f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43"},
 ]
 pytz = [
-    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
-    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
+    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
+    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -504,43 +505,45 @@ sqlparse = [
     {file = "sqlparse-0.4.2.tar.gz", hash = "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae"},
 ]
 strawberry-graphql = [
-    {file = "strawberry-graphql-0.101.0.tar.gz", hash = "sha256:dfc90318f2221dd9cbea38e355a0993528bb45af94d309acecab485b97a4cf79"},
-    {file = "strawberry_graphql-0.101.0-py3-none-any.whl", hash = "sha256:67e54f9457ba66d2e0f71b8ecc39d3c642699f56dc63f2223a6a602abfbae4f4"},
+    {file = "strawberry-graphql-0.113.0.tar.gz", hash = "sha256:ff6743aa2c84ba56d9390460a84311c43aa3a1558a261c2fecea88cd70d0797a"},
+    {file = "strawberry_graphql-0.113.0-py3-none-any.whl", hash = "sha256:eb131a33a51fb53d16eadcbe9651e45744ecfaeeea2d15167bea336a6e1ff9be"},
 ]
-toml = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
-    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
+    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
 ]
 watchdog = [
-    {file = "watchdog-2.1.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9693f35162dc6208d10b10ddf0458cc09ad70c30ba689d9206e02cd836ce28a3"},
-    {file = "watchdog-2.1.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:aba5c812f8ee8a3ff3be51887ca2d55fb8e268439ed44110d3846e4229eb0e8b"},
-    {file = "watchdog-2.1.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ae38bf8ba6f39d5b83f78661273216e7db5b00f08be7592062cb1fc8b8ba542"},
-    {file = "watchdog-2.1.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ad6f1796e37db2223d2a3f302f586f74c72c630b48a9872c1e7ae8e92e0ab669"},
-    {file = "watchdog-2.1.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:922a69fa533cb0c793b483becaaa0845f655151e7256ec73630a1b2e9ebcb660"},
-    {file = "watchdog-2.1.6-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b2fcf9402fde2672545b139694284dc3b665fd1be660d73eca6805197ef776a3"},
-    {file = "watchdog-2.1.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3386b367e950a11b0568062b70cc026c6f645428a698d33d39e013aaeda4cc04"},
-    {file = "watchdog-2.1.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f1c00aa35f504197561060ca4c21d3cc079ba29cf6dd2fe61024c70160c990b"},
-    {file = "watchdog-2.1.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b52b88021b9541a60531142b0a451baca08d28b74a723d0c99b13c8c8d48d604"},
-    {file = "watchdog-2.1.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8047da932432aa32c515ec1447ea79ce578d0559362ca3605f8e9568f844e3c6"},
-    {file = "watchdog-2.1.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e92c2d33858c8f560671b448205a268096e17870dcf60a9bb3ac7bfbafb7f5f9"},
-    {file = "watchdog-2.1.6-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b7d336912853d7b77f9b2c24eeed6a5065d0a0cc0d3b6a5a45ad6d1d05fb8cd8"},
-    {file = "watchdog-2.1.6-py3-none-manylinux2014_aarch64.whl", hash = "sha256:cca7741c0fcc765568350cb139e92b7f9f3c9a08c4f32591d18ab0a6ac9e71b6"},
-    {file = "watchdog-2.1.6-py3-none-manylinux2014_armv7l.whl", hash = "sha256:25fb5240b195d17de949588628fdf93032ebf163524ef08933db0ea1f99bd685"},
-    {file = "watchdog-2.1.6-py3-none-manylinux2014_i686.whl", hash = "sha256:be9be735f827820a06340dff2ddea1fb7234561fa5e6300a62fe7f54d40546a0"},
-    {file = "watchdog-2.1.6-py3-none-manylinux2014_ppc64.whl", hash = "sha256:d0d19fb2441947b58fbf91336638c2b9f4cc98e05e1045404d7a4cb7cddc7a65"},
-    {file = "watchdog-2.1.6-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:3becdb380d8916c873ad512f1701f8a92ce79ec6978ffde92919fd18d41da7fb"},
-    {file = "watchdog-2.1.6-py3-none-manylinux2014_s390x.whl", hash = "sha256:ae67501c95606072aafa865b6ed47343ac6484472a2f95490ba151f6347acfc2"},
-    {file = "watchdog-2.1.6-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e0f30db709c939cabf64a6dc5babb276e6d823fd84464ab916f9b9ba5623ca15"},
-    {file = "watchdog-2.1.6-py3-none-win32.whl", hash = "sha256:e02794ac791662a5eafc6ffeaf9bcc149035a0e48eb0a9d40a8feb4622605a3d"},
-    {file = "watchdog-2.1.6-py3-none-win_amd64.whl", hash = "sha256:bd9ba4f332cf57b2c1f698be0728c020399ef3040577cde2939f2e045b39c1e5"},
-    {file = "watchdog-2.1.6-py3-none-win_ia64.whl", hash = "sha256:a0f1c7edf116a12f7245be06120b1852275f9506a7d90227648b250755a03923"},
-    {file = "watchdog-2.1.6.tar.gz", hash = "sha256:a36e75df6c767cbf46f61a91c70b3ba71811dfa0aca4a324d9407a06a8b7a2e7"},
+    {file = "watchdog-2.1.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:676263bee67b165f16b05abc52acc7a94feac5b5ab2449b491f1a97638a79277"},
+    {file = "watchdog-2.1.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:aa68d2d9a89d686fae99d28a6edf3b18595e78f5adf4f5c18fbfda549ac0f20c"},
+    {file = "watchdog-2.1.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5e2e51c53666850c3ecffe9d265fc5d7351db644de17b15e9c685dd3cdcd6f97"},
+    {file = "watchdog-2.1.8-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:7721ac736170b191c50806f43357407138c6748e4eb3e69b071397f7f7aaeedd"},
+    {file = "watchdog-2.1.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ce7376aed3da5fd777483fe5ebc8475a440c6d18f23998024f832134b2938e7b"},
+    {file = "watchdog-2.1.8-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:f9ee4c6bf3a1b2ed6be90a2d78f3f4bbd8105b6390c04a86eb48ed67bbfa0b0b"},
+    {file = "watchdog-2.1.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:68dbe75e0fa1ba4d73ab3f8e67b21770fbed0651d32ce515cd38919a26873266"},
+    {file = "watchdog-2.1.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0c520009b8cce79099237d810aaa19bc920941c268578436b62013b2f0102320"},
+    {file = "watchdog-2.1.8-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:efcc8cbc1b43902571b3dce7ef53003f5b97fe4f275fe0489565fc6e2ebe3314"},
+    {file = "watchdog-2.1.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:746e4c197ec1083581bb1f64d07d1136accf03437badb5ff8fcb862565c193b2"},
+    {file = "watchdog-2.1.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1ae17b6be788fb8e4d8753d8d599de948f0275a232416e16436363c682c6f850"},
+    {file = "watchdog-2.1.8-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ddde157dc1447d8130cb5b8df102fad845916fe4335e3d3c3f44c16565becbb7"},
+    {file = "watchdog-2.1.8-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4978db33fc0934c92013ee163a9db158ec216099b69fce5aec790aba704da412"},
+    {file = "watchdog-2.1.8-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b962de4d7d92ff78fb2dbc6a0cb292a679dea879a0eb5568911484d56545b153"},
+    {file = "watchdog-2.1.8-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1e5d0fdfaa265c29dc12621913a76ae99656cf7587d03950dfeb3595e5a26102"},
+    {file = "watchdog-2.1.8-py3-none-manylinux2014_armv7l.whl", hash = "sha256:036ed15f7cd656351bf4e17244447be0a09a61aaa92014332d50719fc5973bc0"},
+    {file = "watchdog-2.1.8-py3-none-manylinux2014_i686.whl", hash = "sha256:2962628a8777650703e8f6f2593065884c602df7bae95759b2df267bd89b2ef5"},
+    {file = "watchdog-2.1.8-py3-none-manylinux2014_ppc64.whl", hash = "sha256:156ec3a94695ea68cfb83454b98754af6e276031ba1ae7ae724dc6bf8973b92a"},
+    {file = "watchdog-2.1.8-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:47598fe6713fc1fee86b1ca85c9cbe77e9b72d002d6adeab9c3b608f8a5ead10"},
+    {file = "watchdog-2.1.8-py3-none-manylinux2014_s390x.whl", hash = "sha256:fed4de6e45a4f16e4046ea00917b4fe1700b97244e5d114f594b4a1b9de6bed8"},
+    {file = "watchdog-2.1.8-py3-none-manylinux2014_x86_64.whl", hash = "sha256:24dedcc3ce75e150f2a1d704661f6879764461a481ba15a57dc80543de46021c"},
+    {file = "watchdog-2.1.8-py3-none-win32.whl", hash = "sha256:6ddf67bc9f413791072e3afb466e46cc72c6799ba73dea18439b412e8f2e3257"},
+    {file = "watchdog-2.1.8-py3-none-win_amd64.whl", hash = "sha256:88ef3e8640ef0a64b7ad7394b0f23384f58ac19dd759da7eaa9bc04b2898943f"},
+    {file = "watchdog-2.1.8-py3-none-win_ia64.whl", hash = "sha256:0fb60c7d31474b21acba54079ce9ff0136411183e9a591369417cddb1d7d00d7"},
+    {file = "watchdog-2.1.8.tar.gz", hash = "sha256:6d03149126864abd32715d4e9267d2754cede25a69052901399356ad3bc5ecff"},
 ]
 zipp = [
-    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
-    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
+    {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},
+    {file = "zipp-3.8.0.tar.gz", hash = "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,7 +108,7 @@ python-versions = ">=3.6,<4"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.1"
+version = "4.11.2"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -119,7 +119,7 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
@@ -305,17 +305,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "sentinel"
-version = "0.3.0"
-description = "Create sentinel objects, akin to None, NotImplemented, Ellipsis"
-category = "main"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[package.extras]
-varname = ["varname (>=0.1)"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -333,7 +322,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.98.0"
+version = "0.101.0"
 description = "A library for creating GraphQL APIs"
 category = "main"
 optional = false
@@ -346,14 +335,13 @@ graphql-core = ">=3.2.0,<3.3.0"
 pygments = ">=2.3,<3.0"
 python-dateutil = ">=2.7.0,<3.0.0"
 python-multipart = ">=0.0.5,<0.0.6"
-sentinel = ">=0.3.0,<0.4.0"
 typing_extensions = ">=3.7.4,<5.0.0"
 
 [package.extras]
 asgi = ["starlette (>=0.13.6,<0.17.0)"]
 debug-server = ["starlette (>=0.13.6,<0.17.0)", "uvicorn (>=0.11.6,<0.18.0)"]
-django = ["Django (>=2.2,<4)", "Django (>=2.2,<5)", "asgiref (>=3.2,<4.0)"]
-flask = ["flask (>=1.1,<2.0)"]
+django = ["Django (>=2.2)", "asgiref (>=3.2,<4.0)"]
+flask = ["flask (>=1.1)"]
 opentelemetry = ["opentelemetry-api (<2)", "opentelemetry-sdk (<2)"]
 chalice = ["chalice (>=1.22,<2.0)"]
 pydantic = ["pydantic (<2)"]
@@ -403,7 +391,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "6a3cb326541c8303a1a85702949a5da22e6d23288fe707e8f9b0fad0cb028c74"
+content-hash = "c730e91a5e9057302ca5a1fcd0f7e06cefa21653daeaae0fe2f416f0cd45a776"
 
 [metadata.files]
 asgiref = [
@@ -446,8 +434,8 @@ graphql-core = [
     {file = "graphql_core-3.2.0-py3-none-any.whl", hash = "sha256:0dda7e63676f119bb3d814621190fedad72fda07a8e9ab780bedd9f1957c6dc6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.1-py3-none-any.whl", hash = "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"},
-    {file = "importlib_metadata-4.11.1.tar.gz", hash = "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c"},
+    {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
+    {file = "importlib_metadata-4.11.2.tar.gz", hash = "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -507,10 +495,6 @@ pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
     {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
-sentinel = [
-    {file = "sentinel-0.3.0-py3-none-any.whl", hash = "sha256:bd8710dd26752039c668604f6be2aaf741b56f7811c5924a4dcdfd74359244f3"},
-    {file = "sentinel-0.3.0.tar.gz", hash = "sha256:f28143aa4716dbc8f6193f5682176a3c33cd26aaae05d9ecf66c186a9887cc2d"},
-]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -520,8 +504,8 @@ sqlparse = [
     {file = "sqlparse-0.4.2.tar.gz", hash = "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae"},
 ]
 strawberry-graphql = [
-    {file = "strawberry-graphql-0.98.0.tar.gz", hash = "sha256:437e08897f8109373bbf6a80c26479625493d79dd44e14afd78fef2c79b2db36"},
-    {file = "strawberry_graphql-0.98.0-py3-none-any.whl", hash = "sha256:6e8f826163acd839cd2e5cc1d6ce9ff46582157f8577e4471fb835172336bf44"},
+    {file = "strawberry-graphql-0.101.0.tar.gz", hash = "sha256:dfc90318f2221dd9cbea38e355a0993528bb45af94d309acecab485b97a4cf79"},
+    {file = "strawberry_graphql-0.101.0-py3-none-any.whl", hash = "sha256:67e54f9457ba66d2e0f71b8ecc39d3c642699f56dc63f2223a6a602abfbae4f4"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ Django = ">=3.0"
 strawberry-graphql = ">=0.100.0"
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.1.1"
-pytest-asyncio = "^0.14.0"
+pytest = "^7.1.2"
+pytest-asyncio = "^0.18.3"
 pytest-django = "^4.1.0"
 pytest-pythonpath = "^0.7.3"
 pytest-watch = "^4.2.0"
@@ -40,6 +40,5 @@ lines_after_imports = 2
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.django_settings"
-python_paths = "."
 testpaths = ["tests"]
 filterwarnings = "ignore:.*is deprecated.*:DeprecationWarning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strawberry-graphql-django"
-packages = [ { include = "strawberry_django" } ]
+packages = [{ include = "strawberry_django" }]
 version = "0.3rc1"
 description = "Strawberry GraphQL Django extension"
 authors = ["Lauri Hintsala <lauri.hintsala@verkkopaja.fi>"]
@@ -8,12 +8,15 @@ repository = "https://github.com/strawberry-graphql/strawberry-graphql-django"
 license = "MIT"
 readme = "README.md"
 keywords = ["graphql", "api", "django"]
-classifiers = [ "Topic :: Software Development :: Libraries", "Topic :: Software Development :: Libraries :: Python Modules" ]
+classifiers = [
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 Django = ">=3.0"
-strawberry-graphql = ">=0.69.0"
+strawberry-graphql = ">=0.100.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.1"

--- a/strawberry_django/__init__.py
+++ b/strawberry_django/__init__.py
@@ -1,3 +1,6 @@
+# FIXME: We should stop exporting this in the future and auto directly from strawberry
+from strawberry import auto
+
 from . import auth, filters, mutations, ordering, types
 from .fields.field import field
 from .fields.types import (
@@ -8,7 +11,6 @@ from .fields.types import (
     ManyToOneInput,
     OneToManyInput,
     OneToOneInput,
-    auto,
     is_auto,
 )
 from .filters import filter_deprecated as filter

--- a/strawberry_django/__init__.py
+++ b/strawberry_django/__init__.py
@@ -1,9 +1,11 @@
-# FIXME: We should stop exporting this in the future and auto directly from strawberry
-from strawberry import auto
+import warnings
+from typing import Any, Dict
+
+from strawberry import auto as _deprecated_auto  # noqa: F401
 
 from . import auth, filters, mutations, ordering, types
 from .fields.field import field
-from .fields.types import (
+from .fields.types import (  # noqa: F401
     DjangoFileType,
     DjangoImageType,
     DjangoModelType,
@@ -11,12 +13,31 @@ from .fields.types import (
     ManyToOneInput,
     OneToManyInput,
     OneToOneInput,
-    is_auto,
+    is_auto as _deprecated_is_auto,
 )
 from .filters import filter_deprecated as filter
 from .resolvers import django_resolver
 from .type import input, mutation, type
 from .utils import fields
+
+
+_deprecated_names: Dict[str, str] = {
+    "auto": (
+        "importing `auto` from `strawberry_django` is deprecated, "
+        "import instead from `strawberry` directly."
+    ),
+    "is_auto": (
+        "`is_auto` is deprecated use `isinstance(value, StrawberryAuto)` instead."
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _deprecated_names:
+        warnings.warn(_deprecated_names[name], DeprecationWarning, stacklevel=2)
+        return globals()[f"_deprecated_{name}"]
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 __all__ = [
@@ -26,8 +47,6 @@ __all__ = [
     "ordering",
     "types",
     "field",
-    "auto",
-    "is_auto",
     "DjangoFileType",
     "DjangoImageType",
     "DjangoModelType",

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -1,16 +1,14 @@
 import datetime
 import decimal
 import uuid
-from typing import Any, List, Optional, get_args, get_origin
+from typing import List, Optional
 
 import django
 import strawberry
 from django.db.models import fields
 from django.db.models.fields.reverse_related import ForeignObjectRel, ManyToOneRel
-from strawberry.annotation import StrawberryAnnotation
 from strawberry.arguments import UNSET
-from strawberry.auto import StrawberryAuto, auto
-from typing_extensions import Annotated
+from strawberry.auto import StrawberryAuto
 
 from .. import filters
 
@@ -163,26 +161,8 @@ def get_model_field(model, field_name):
         raise e
 
 
-# FIXME: maybe this should be defined at strawberry/auto.py?
 def is_auto(type_):
-    if isinstance(type_, StrawberryAnnotation):
-        annotation = type_.annotation
-        if isinstance(annotation, str):
-            namespace = type_.namespace
-            type_ = namespace and namespace.get(annotation)
-        else:
-            type_ = annotation
-
-    if type_ is auto:
-        return True
-
-    # Support uses of Annotated[auto, something()]
-    if get_origin(type_) is Annotated:
-        args = get_args(type_)
-        if args[0] is Any:
-            return any(isinstance(arg, StrawberryAuto) for arg in args[1:])
-
-    return False
+    return isinstance(type_, StrawberryAuto)
 
 
 def is_optional(model_field, is_input, partial):

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -9,7 +9,6 @@ from strawberry.arguments import UNSET
 from . import utils
 from .fields.field import StrawberryDjangoField
 from .fields.types import (
-    auto,
     get_model_field,
     is_optional,
     resolve_model_field_name,
@@ -150,7 +149,7 @@ def process_type(cls, model, *, filters=UNSET, pagination=UNSET, order=UNSET, **
             else field.type_annotation.annotation
         )
         if annotation is None:
-            annotation = StrawberryAnnotation(auto)
+            annotation = StrawberryAnnotation(strawberry.auto)
         cls_annotations[field.name] = annotation
         setattr(cls, field.name, field)
 

--- a/tests/fields/test_attributes.py
+++ b/tests/fields/test_attributes.py
@@ -1,7 +1,7 @@
 from django.db import models
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto
 
 
 class FieldAttributeModel(models.Model):

--- a/tests/fields/test_input.py
+++ b/tests/fields/test_input.py
@@ -1,9 +1,9 @@
 import strawberry
 from django.db import models
+from strawberry import auto
 from strawberry.type import StrawberryOptional
 
 import strawberry_django
-from strawberry_django import auto
 
 
 class InputFieldsModel(models.Model):

--- a/tests/fields/test_ref.py
+++ b/tests/fields/test_ref.py
@@ -1,7 +1,7 @@
 from django.db import models
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto
 
 
 def test_forward_reference():

--- a/tests/fields/test_relations.py
+++ b/tests/fields/test_relations.py
@@ -2,10 +2,10 @@ from typing import List
 
 import strawberry
 from django.db import models
+from strawberry import auto
 from strawberry.type import StrawberryList, StrawberryOptional
 
 import strawberry_django
-from strawberry_django import auto
 
 
 class ParentModel(models.Model):

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -9,12 +9,11 @@ import pytest
 import strawberry
 from django.db import models
 from strawberry import auto
-from strawberry.annotation import StrawberryAnnotation
 from strawberry.enum import EnumDefinition, EnumValue
 from strawberry.type import StrawberryList, StrawberryOptional
 
 import strawberry_django
-from strawberry_django import fields, is_auto
+from strawberry_django import fields
 
 
 class FieldTypesModel(models.Model):
@@ -356,33 +355,3 @@ def test_type_from_type():
             StrawberryOptional(strawberry_django.ManyToManyInput),
         ),
     ]
-
-
-def test_is_auto_passing_auto():
-    assert is_auto(auto)
-
-
-def test_is_auto_passing_non_auto():
-    assert not is_auto(int)
-
-
-def test_is_auto_passing_auto_strawberry_annotation():
-    assert is_auto(StrawberryAnnotation(auto))
-
-
-def test_is_auto_passing_non_auto_strawberry_annotation():
-    assert not is_auto(StrawberryAnnotation(int))
-
-
-def test_is_auto_passing_auto_as_str_strawberry_annotation():
-    assert is_auto(StrawberryAnnotation("auto", namespace={"auto": auto}))
-
-
-def test_is_auto_passing_aliased_auto_as_str_strawberry_annotation():
-    assert is_auto(
-        StrawberryAnnotation("aliased_auto", namespace={"aliased_auto": auto})
-    )
-
-
-def test_is_auto_passing_non_auto_as_str_strawberry_annotation():
-    assert not is_auto(StrawberryAnnotation("SomeType", namespace={"SomeType": type}))

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -8,12 +8,13 @@ import django
 import pytest
 import strawberry
 from django.db import models
+from strawberry import auto
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.enum import EnumDefinition, EnumValue
 from strawberry.type import StrawberryList, StrawberryOptional
 
 import strawberry_django
-from strawberry_django import auto, fields, is_auto
+from strawberry_django import fields, is_auto
 
 
 class FieldTypesModel(models.Model):

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -3,10 +3,10 @@ from typing import List
 
 import pytest
 import strawberry
+from strawberry import auto
 from strawberry.annotation import StrawberryAnnotation
 
 import strawberry_django
-from strawberry_django import auto
 from tests import models, utils
 
 

--- a/tests/filters/test_types.py
+++ b/tests/filters/test_types.py
@@ -1,8 +1,9 @@
 import strawberry
+from strawberry import auto
 from strawberry.type import StrawberryOptional
 
 import strawberry_django
-from strawberry_django import auto, fields
+from strawberry_django import fields
 from strawberry_django.filters import DjangoModelFilterInput
 
 from .. import models

--- a/tests/mutations/conftest.py
+++ b/tests/mutations/conftest.py
@@ -2,9 +2,10 @@ from typing import List
 
 import pytest
 import strawberry
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto, mutations
+from strawberry_django import mutations
 
 from .. import models, utils
 from ..types import (

--- a/tests/queries/test_files.py
+++ b/tests/queries/test_files.py
@@ -3,9 +3,9 @@ from typing import List
 import pytest
 import strawberry
 from django.db import models
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto
 
 from .. import utils
 

--- a/tests/queries/test_m2m_through.py
+++ b/tests/queries/test_m2m_through.py
@@ -2,9 +2,9 @@ from typing import List, Optional
 
 import strawberry
 from django.db import models
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto
 
 
 class MemberModel(models.Model):

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -2,9 +2,9 @@ from typing import List
 
 import pytest
 import strawberry
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto
 from tests import models, utils
 from tests.types import Fruit
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -2,9 +2,9 @@ from typing import List
 
 import pytest
 import strawberry
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto
 from tests import models, utils
 
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,9 +2,9 @@ from typing import List
 
 import pytest
 import strawberry
+from strawberry import auto
 
 import strawberry_django
-from strawberry_django import auto
 
 from . import models, utils
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,28 +1,8 @@
 from strawberry import auto
-from strawberry.annotation import StrawberryAnnotation
-from typing_extensions import Annotated
 
 import strawberry_django
-from strawberry_django.fields.types import is_auto
 
 from .models import User
-
-
-def test_is_auto():
-    assert is_auto(auto) is True
-    assert is_auto(object) is False
-
-
-def test_is_auto_with_annotation():
-    annotation = StrawberryAnnotation(auto)
-    assert is_auto(annotation) is True
-    str_annotation = StrawberryAnnotation("auto", namespace=globals())
-    assert is_auto(str_annotation) is True
-
-
-def test_is_auto_with_annotated():
-    assert is_auto(Annotated[auto, object()]) is True
-    assert is_auto(Annotated[str, auto]) is False
 
 
 def test_type_instance():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,28 @@
+from strawberry import auto
+from strawberry.annotation import StrawberryAnnotation
+from typing_extensions import Annotated
+
 import strawberry_django
-from strawberry_django import auto
+from strawberry_django.fields.types import is_auto
 
 from .models import User
+
+
+def test_is_auto():
+    assert is_auto(auto) is True
+    assert is_auto(object) is False
+
+
+def test_is_auto_with_annotation():
+    annotation = StrawberryAnnotation(auto)
+    assert is_auto(annotation) is True
+    str_annotation = StrawberryAnnotation("auto", namespace=globals())
+    assert is_auto(str_annotation) is True
+
+
+def test_is_auto_with_annotated():
+    assert is_auto(Annotated[auto, object()]) is True
+    assert is_auto(Annotated[str, auto]) is False
 
 
 def test_type_instance():

--- a/tests/types.py
+++ b/tests/types.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import List
 
+from strawberry import auto
+
 import strawberry_django
-from strawberry_django import auto
 
 from . import models
 

--- a/tests/types2/test_input.py
+++ b/tests/types2/test_input.py
@@ -1,8 +1,9 @@
 import strawberry
+from strawberry import auto
 from strawberry.type import StrawberryOptional
 
 import strawberry_django
-from strawberry_django import auto, fields
+from strawberry_django import fields
 
 from .test_type import TypeModel
 

--- a/tests/types2/test_type.py
+++ b/tests/types2/test_type.py
@@ -1,9 +1,10 @@
 import strawberry
 from django.db import models
+from strawberry import auto
 from strawberry.type import StrawberryList, StrawberryOptional
 
 import strawberry_django
-from strawberry_django import auto, fields
+from strawberry_django import fields
 
 
 class TypeModel(models.Model):


### PR DESCRIPTION
This makes it possible to use "strawberry.auto" directly instead of
having to use own own auto.

We are still exporting auto in our `__init__` file for backwards
compatibility, but we should remove that as well in the future.
