### PR TITLE
Fix ordering with custom filters

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -135,7 +135,7 @@ class StrawberryDjangoField(
         get_queryset = getattr(type_, "get_queryset", None)
         if get_queryset:
             queryset = get_queryset(self, queryset, info, **kwargs)
-        return super().get_queryset(queryset, info, order, **kwargs)
+        return super().get_queryset(queryset, info, order=order, **kwargs)
 
 
 def field(

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -24,8 +24,8 @@ class StrawberryDjangoFieldBase:
 
 
 class StrawberryDjangoField(
-    StrawberryDjangoFieldOrdering,
     StrawberryDjangoFieldFilters,
+    StrawberryDjangoFieldOrdering,
     StrawberryDjangoPagination,
     StrawberryDjangoFieldBase,
     StrawberryField,


### PR DESCRIPTION
The current MRO applies the ordering before any filters are applied. This is an issue if your filter uses any annotations to do its filtering, as `Queryset`s lose all of their ordering when an annotation is applied. To solve for this, we can change the MRO of `get_queryset` on `StrawberryDjangoField` to apply the filters first, and the ordering after, there by removing the issue