### PR TITLE
bugfix: ignore filters argument if it is an arbitary argument

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -117,7 +117,12 @@ def build_filter_kwargs(filters):
 def apply(filters, queryset, pk=UNSET):
     if not is_unset(pk):
         queryset = queryset.filter(pk=pk)
-    if is_unset(filters) or filters is None:
+    if (
+        is_unset(filters)
+        or filters is None
+        or not hasattr(filters, "_django_type")
+        or not filters._django_type.is_filter
+    ):
         return queryset
 
     filter_method = getattr(filters, "filter", None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The current behavior is that every filters argument is treated as filter. But filters can also be an arbitrary argument which should not trigger the filter logic.
This MR prevents this by applying checks if filters is really a filter 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
