### PR TITLE
Change order of inheritance for `StrawberryDjangoField`

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -24,10 +24,10 @@ class StrawberryDjangoFieldBase:
 
 
 class StrawberryDjangoField(
-    StrawberryDjangoFieldFilters,
-    StrawberryDjangoFieldOrdering,
-    StrawberryDjangoFieldBase,
     StrawberryDjangoPagination,
+    StrawberryDjangoFieldOrdering,
+    StrawberryDjangoFieldFilters,
+    StrawberryDjangoFieldBase,
     StrawberryField,
 ):
     """Basic field

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -166,5 +166,5 @@ class StrawberryDjangoFieldFilters:
         return None
 
     def get_queryset(self, queryset, info, pk=UNSET, filters=UNSET, **kwargs):
-        queryset = apply(filters, queryset, pk)
-        return super().get_queryset(queryset, info, **kwargs)
+        queryset = super().get_queryset(queryset, info, **kwargs)
+        return apply(filters, queryset, pk)

--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -67,5 +67,5 @@ class StrawberryDjangoFieldOrdering:
         return super().arguments + arguments
 
     def get_queryset(self, queryset, info, order=UNSET, **kwargs):
-        queryset = apply(order, queryset)
-        return super().get_queryset(queryset, info, **kwargs)
+        queryset = super().get_queryset(queryset, info, **kwargs)
+        return apply(order, queryset)

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -47,5 +47,5 @@ class StrawberryDjangoPagination:
         return None
 
     def get_queryset(self, queryset, info, pagination=UNSET, **kwargs):
-        queryset = apply(pagination, queryset)
-        return super().get_queryset(queryset, info, **kwargs)
+        queryset = super().get_queryset(queryset, info, **kwargs)
+        return apply(pagination, queryset)


### PR DESCRIPTION
The current MRO of `StrawberryDjangoField` has it applying pagination before the `StrawberryDjangoFieldBase.get_queryset` resolves. Since pagination does array slicing, if you have a custom `get_queryset` defined on the type, it will raise the following error:
```
AssertionError: Cannot filter a query once a slice has been taken.
```

By changing the MRO to have pagination come after field base, we will avoid this issue, since pagination will be applied last