### PR TITLE
feat: allow Enums to work with FilterLookup

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -108,6 +108,8 @@ def build_filter_kwargs(filters):
                 subfield_name,
                 subfield_value,
             ) in subfield_filter_kwargs.items():
+                if isinstance(subfield_value, Enum):
+                    subfield_value = subfield_value.value
                 filter_kwargs[f"{field_name}__{subfield_name}"] = subfield_value
             filter_methods.extend(subfield_filter_methods)
         else:


### PR DESCRIPTION
Update `build_filter_kwargs` to handle when an `Enum` is provided to the `FilterLookup`. This is similar to #100, but adds support for if the `Enum` is nested