### PR TITLE
fix: pass through more field attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Pyenv version
+.python-version

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -75,17 +75,20 @@ class StrawberryDjangoField(
         if utils.is_strawberry_django_field(field) and not field.origin_django_type:
             return field
 
-        default = getattr(field, "default", getattr(field, "default", UNSET))
         new_field = StrawberryDjangoField(
-            base_resolver=getattr(field, "base_resolver", None),
-            default_factory=field.default_factory,
-            default=default,
-            django_name=getattr(field, "django_name", field.name),
-            graphql_name=getattr(field, "graphql_name", None),
             python_name=field.name,
+            graphql_name=getattr(field, "graphql_name", None),
             type_annotation=field.type_annotation
             if hasattr(field, "type_annotation")
             else StrawberryAnnotation(field.type),
+            description=getattr(field, "description", None),
+            base_resolver=getattr(field, "base_resolver", None),
+            permission_classes=getattr(field, "permission_classes", []),
+            default=getattr(field, "default", UNSET),
+            default_factory=field.default_factory,
+            deprecation_reason=getattr(field, "deprecation_reason", None),
+            directives=getattr(field, "directives", []),
+            django_name=getattr(field, "django_name", field.name),
         )
         new_field.is_auto = getattr(field, "is_auto", False)
         new_field.origin_django_type = getattr(field, "origin_django_type", None)

--- a/tests/fields/test_attributes.py
+++ b/tests/fields/test_attributes.py
@@ -1,5 +1,6 @@
+import strawberry
 from django.db import models
-from strawberry import auto
+from strawberry import BasePermission, auto
 
 import strawberry_django
 
@@ -18,3 +19,25 @@ def test_default_django_name():
         ("field", "field"),
         ("field2", "field"),
     ]
+
+
+def test_field_permission_classes():
+    class TestPermission(BasePermission):
+        pass
+
+    @strawberry_django.type(FieldAttributeModel)
+    class Type:
+        field: auto = strawberry.field(permission_classes=[TestPermission])
+
+        @strawberry.field(permission_classes=[TestPermission])
+        def custom_resolved_field(self):
+            return self.field
+
+    assert sorted(
+        [(f.name, f.permission_classes) for f in Type._type_definition.fields]
+    ) == sorted(
+        [
+            ("field", [TestPermission]),
+            ("custom_resolved_field", [TestPermission]),
+        ]
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When attempting to add field-level permissions to a model, e.g. 

```python
@strawberry_django.type(FieldAttributeModel)
class Type:
    field: auto = strawberry.field(permission_classes=[TestPermission])
```

I expected that the `TestPermission` class would be applied to that field when resolving. It appeared that the permissions classes had been stripped from the field definition though.

This PR updates `StrawberryDjangoField.from_field()` to pass through all of the attributes which may be needed.

I'd be happy to add some further tests if required?

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
