### PR TITLE
fix: resolve `ManyToManyRel` and `ManyToOneRel` as non-null lists

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -180,6 +180,10 @@ def is_optional(model_field, is_input, partial):
         has_default = model_field.default is not fields.NOT_PROVIDED
         if model_field.blank or has_default:
             return True
-    if model_field.null:
-        return True
+    if not isinstance(
+        model_field,
+        (fields.reverse_related.ManyToManyRel, fields.reverse_related.ManyToOneRel),
+    ) or isinstance(model_field, fields.reverse_related.OneToOneRel):
+        # OneToOneRel is the subclass of ManyToOneRel, so additional check is needed
+        return model_field.null
     return False

--- a/tests/auth/test_types.py
+++ b/tests/auth/test_types.py
@@ -1,5 +1,5 @@
 from django.contrib import auth
-from strawberry.type import StrawberryList, StrawberryOptional
+from strawberry.type import StrawberryList
 
 import strawberry_django
 from strawberry_django import DjangoModelType, auto, fields
@@ -27,5 +27,5 @@ def test_group_type():
 
     assert [(f.name, f.type or f.child.type) for f in fields(Type)] == [
         ("name", str),
-        ("users", StrawberryOptional(StrawberryList(DjangoModelType))),
+        ("users", StrawberryList(DjangoModelType)),
     ]

--- a/tests/fields/test_relations.py
+++ b/tests/fields/test_relations.py
@@ -3,7 +3,7 @@ from typing import List
 import strawberry
 from django.db import models
 from strawberry import auto
-from strawberry.type import StrawberryList, StrawberryOptional
+from strawberry.type import StrawberryList
 
 import strawberry_django
 
@@ -38,7 +38,7 @@ def test_relation():
     ] == [
         ("id", strawberry.ID, False),
         ("name", str, False),
-        ("children", StrawberryOptional(StrawberryList(Child)), True),
+        ("children", StrawberryList(Child), True),
     ]
 
 

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -204,7 +204,7 @@ def test_related_fields():
         ),
         (
             "related_foreign_key",
-            StrawberryOptional(StrawberryList(strawberry_django.DjangoModelType)),
+            StrawberryList(strawberry_django.DjangoModelType),
             True,
         ),
         (
@@ -214,7 +214,7 @@ def test_related_fields():
         ),
         (
             "related_many_to_many",
-            StrawberryOptional(StrawberryList(strawberry_django.DjangoModelType)),
+            StrawberryList(strawberry_django.DjangoModelType),
             True,
         ),
     ]

--- a/tests/types2/test_type.py
+++ b/tests/types2/test_type.py
@@ -94,7 +94,7 @@ def test_relationship_inherit(testtype):
         ("foreign_key", strawberry_django.DjangoModelType, False),
         (
             "related_foreign_key",
-            StrawberryOptional(StrawberryList(strawberry_django.DjangoModelType)),
+            StrawberryList(strawberry_django.DjangoModelType),
             True,
         ),
         ("one_to_one", strawberry_django.DjangoModelType, False),
@@ -110,7 +110,7 @@ def test_relationship_inherit(testtype):
         ),
         (
             "related_many_to_many",
-            StrawberryOptional(StrawberryList(strawberry_django.DjangoModelType)),
+            StrawberryList(strawberry_django.DjangoModelType),
             True,
         ),
         ("another_name", strawberry_django.DjangoModelType, False),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR is intended to fix #128. Reverse-related fields like `ManyToManyRel` and `ManyToOneRel` are now resolved as non-null lists, instead of nullable lists, since a query of such relations from the database will always be a list. 

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #128 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
