### PR TITLE
feature: allow overriding field class

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -22,6 +22,10 @@ class StrawberryDjangoFieldBase:
         type_ = utils.unwrap_type(self.type)
         return utils.get_django_model(type_)
 
+    @classmethod
+    def from_field(cls, field, django_type):
+        raise NotImplementedError
+
 
 class StrawberryDjangoField(
     StrawberryDjangoPagination,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,8 +1,10 @@
 from strawberry import auto
 
 import strawberry_django
+from strawberry_django.fields.field import StrawberryDjangoField
 
 from .models import User
+from .utils import get_field
 
 
 def test_type_instance():
@@ -36,3 +38,36 @@ def test_input_instance():
     user = InputType(1, "user")
     assert user.id == 1
     assert user.name == "user"
+
+
+def test_custom_field_cls():
+    """Custom field_cls is applied to all fields."""
+
+    class CustomStrawberryDjangoField(StrawberryDjangoField):
+        pass
+
+    @strawberry_django.type(User, field_cls=CustomStrawberryDjangoField)
+    class UserType:
+        id: int
+        name: auto
+
+    assert all(
+        isinstance(field, CustomStrawberryDjangoField)
+        for field in UserType._type_definition.fields
+    )
+
+
+def test_custom_field_cls__explicit_field_type():
+    """Custom field_cls is applied to all fields."""
+
+    class CustomStrawberryDjangoField(StrawberryDjangoField):
+        pass
+
+    @strawberry_django.type(User, field_cls=CustomStrawberryDjangoField)
+    class UserType:
+        id: int
+        name: auto = strawberry_django.field()
+
+    assert isinstance(get_field(UserType, "id"), CustomStrawberryDjangoField)
+    assert isinstance(get_field(UserType, "name"), StrawberryDjangoField)
+    assert not isinstance(get_field(UserType, "name"), CustomStrawberryDjangoField)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,3 +47,13 @@ def dataclass(model):
         return dataclasses.dataclass(cls)
 
     return wrapper
+
+
+def get_field(cls, field_name):
+    matches = [
+        field for field in cls._type_definition.fields if field.name == field_name
+    ]
+    try:
+        return matches[0]
+    except IndexError:
+        raise ValueError(f"{cls} does cont contain a field named {field_name}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
For a project I am working on there are a couple of ways in which I need to extend the behavior of the `StrawberryDjangoField` to accommodate:
1. A different pagination style
2. The ability to null some fields when permission is denied, rather than raising errors. This is for schema backwards compatibility
3. Some altered behavior on the filters

As such, I need to be able to have fields be created with my custom field class rather than the base class.

This PR introduces a `field_cls` argument which can be passed to `@strawberry_django.type` and set to an alternative implementation.

N.B. I am aware some documentation updates may be needed, but I wanted to get some feedback on how acceptable the maintainers find this approach before continuing to work on it.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
