### PR TITLE
feat: Use Django textual metadata in GraphQL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ class Fruit(models.Model):
             related_name='fruits', on_delete=models.CASCADE)
 
 class Color(models.Model):
-    name = models.CharField(max_length=20,
-           help_text="field description")
+    name = models.CharField(
+      max_length=20,
+      help_text="field description",
+    )
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ Full documentation is available under [docs](https://strawberry-graphql.github.i
 from django.db import models
 
 class Fruit(models.Model):
+    """A tasty treat"""
     name = models.CharField(max_length=20)
     color = models.ForeignKey('Color', blank=True, null=True,
             related_name='fruits', on_delete=models.CASCADE)
 
 class Color(models.Model):
-    name = models.CharField(max_length=20)
+    name = models.CharField(max_length=20,
+           help_text="field description")
 ```
 
 ```python
@@ -72,6 +74,9 @@ schema = strawberry.Schema(query=Query)
 Code above generates following schema.
 
 ```schema
+"""
+A tasty treat
+"""
 type Fruit {
   id: ID!
   name: String!
@@ -80,6 +85,9 @@ type Fruit {
 
 type Color {
   id: ID!
+  """
+  field description
+  """
   name: String!
   fruits: [Fruit!]
 }

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ class Fruit(models.Model):
 
 class Color(models.Model):
     name = models.CharField(
-      max_length=20,
-      help_text="field description",
+        max_length=20,
+        help_text="field description",
     )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,8 +32,8 @@ class Fruit(models.Model):
 
 class Color(models.Model):
     name = models.CharField(
-      max_length=20,
-      help_text="field description",
+        max_length=20,
+        help_text="field description",
     )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,8 +31,10 @@ class Fruit(models.Model):
             related_name='fruits', on_delete=models.CASCADE)
 
 class Color(models.Model):
-    name = models.CharField(max_length=20,
-           help_text="field description")
+    name = models.CharField(
+      max_length=20,
+      help_text="field description",
+    )
 ```
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,14 @@ class Query:
 schema = strawberry.Schema(query=Query)
 ```
 
+```python
+# settings.py
+STRAWBERRY_DJANGO = {
+    "FIELD_DESCRIPTION_FROM_HELP_TEXT": True,
+    "TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING": True,
+}
+```
+
 Code above generates following schema.
 
 ```schema

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,12 +25,14 @@ Strawberry integration with Django.
 from django.db import models
 
 class Fruit(models.Model):
+    """A tasty treat"""
     name = models.CharField(max_length=20)
     color = models.ForeignKey('Color', blank=True, null=True,
             related_name='fruits', on_delete=models.CASCADE)
 
 class Color(models.Model):
-    name = models.CharField(max_length=20)
+    name = models.CharField(max_length=20,
+           help_text="field description")
 ```
 
 ```python
@@ -69,6 +71,9 @@ schema = strawberry.Schema(query=Query)
 Code above generates following schema.
 
 ```schema
+"""
+A tasty treat
+"""
 type Fruit {
   id: ID!
   name: String!
@@ -77,6 +82,9 @@ type Fruit {
 
 type Color {
   id: ID!
+  """
+  field description
+  """
   name: String!
   fruits: [Fruit!]
 }

--- a/docs/references/fields.md
+++ b/docs/references/fields.md
@@ -56,6 +56,7 @@ class Color:
         field_name='fruit_set',
         filters=FruitFilter,
         order=FruitOrder,
-        pagination=True
+        pagination=True,
+        description="A list of fruits with this color"
     )
 ```

--- a/docs/references/settings.md
+++ b/docs/references/settings.md
@@ -1,0 +1,24 @@
+# Django Settings
+
+Certain features of this library are configured using custom [Django settings](https://docs.djangoproject.com/en/4.1/topics/settings/).
+
+## STRAWBERRY_DJANGO
+
+A dictionary with the following optional keys:
+
+- **`FIELD_DESCRIPTION_FROM_HELP_TEXT`** (Default: `False`)
+
+      If True, [GraphQL field's description](https://spec.graphql.org/draft/#sec-Descriptions) will be fetched from the corresponding Django model field's [`help_text` attribute](https://docs.djangoproject.com/en/4.1/ref/models/fields/#help-text). If a description is provided using [field customization](fields.md#field-customization), that description will be used instead.
+
+- **`TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING`** (Default: `False`)
+
+      If True, [GraphQL type descriptions](https://spec.graphql.org/draft/#sec-Descriptions) will be fetched from the corresponding Django model's [docstring](https://docs.python.org/3/glossary.html#term-docstring). If a description is provided using the [`strawberry_django.type` decorator](types.md#types-from-django-models), that description will be used instead.
+
+These features can be enabled by adding this code to your `settings.py` file.
+
+```python
+STRAWBERRY_DJANGO = {
+    "FIELD_DESCRIPTION_FROM_HELP_TEXT": True,
+    "TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING": True,
+}
+```

--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -55,12 +55,12 @@ class ColorPartialInput:
 
 ## Types from Django models
 
-Django models can be converted to `strawberry` Types with the `strawberry_django.type` decorator.
+Django models can be converted to `strawberry` Types with the `strawberry_django.type` decorator. Custom descriptions can be added using the `description` keyword argument (See: [`strawberry.type` decorator API](https://strawberry.rocks/docs/types/object-types#api)).
 
 ```python
 import strawberry
 
-@strawberry.django.type(models.Fruit)
+@strawberry.django.type(models.Fruit, description="A tasty snack")
 class Fruit:
     ...
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - Resolvers: ./references/resolvers.md
       - Types: ./references/types.md
       - Views: ./references/views.md
+      - Settings: ./references/settings.md
 #      (TBD's)
       - Permissions: ./references/permissions.md
       - Subscriptions: ./references/subscriptions.md

--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -1,0 +1,41 @@
+"""
+Code for interacting with Django settings.
+"""
+from typing import TypedDict
+
+from django.conf import settings
+
+
+class StrawberryDjangoSettings(TypedDict):
+    """
+    Dictionary defining the shape `settings.STRAWBERRY_DJANGO` should have.
+
+    All settings are optional and have defaults as described in their docstrings and
+    defined in `DEFAULT_DJANGO_SETTINGS`.
+    """
+
+    FIELD_DESCRIPTION_FROM_HELP_TEXT: bool
+    """(Default: False) If True, field descriptions will be fetched from the
+    corresponding model field's `help_text` attribute."""
+
+    TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING: bool
+    """(Default: False) If True, type descriptions will be fetched from the
+    corresponding model's docstring."""
+
+
+DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
+    FIELD_DESCRIPTION_FROM_HELP_TEXT=False,
+    TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING=False,
+)
+
+
+def strawberry_django_settings() -> StrawberryDjangoSettings:
+    """
+    Return the dictionary from `settings.STRAWBERRY_DJANGO`, with defaults for missing
+    keys.
+
+    Preferred to direct access for the type hints and defaults.
+    """
+    defaults = DEFAULT_DJANGO_SETTINGS
+    customized = {**defaults, **getattr(settings, "STRAWBERRY_DJANGO", {})}
+    return customized

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -1,4 +1,5 @@
 import dataclasses
+from inspect import cleandoc
 from typing import Any, Optional, TypeVar
 
 import django
@@ -62,6 +63,11 @@ def get_field(django_type, field_name, field_annotation=None):
             model_field, django_type.is_input, django_type.is_filter
         )
         field.is_relation = model_field.is_relation
+
+        # Use the Django field help_text if no other description is available.
+        if not field.description:
+            model_field_help_text = getattr(model_field, "help_text", "")
+            field.description = str(model_field_help_text) or None
     except django.core.exceptions.FieldDoesNotExist:
         if field.django_name or field.is_auto:
             raise  # field should exist, reraise caught exception
@@ -178,7 +184,10 @@ def process_type(
     if not hasattr(cls, "is_type_of"):
         cls.is_type_of = lambda obj, _info: isinstance(obj, (cls, model))
 
-    strawberry.type(cls, **kwargs)
+    # Get type description from either kwargs, or the model's docstring
+    description = kwargs.pop("description", cleandoc(model.__doc__))
+
+    strawberry.type(cls, description=description, **kwargs)
 
     # restore original annotations for further use
     cls.__annotations__ = original_annotations

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -185,7 +185,7 @@ def process_type(
         cls.is_type_of = lambda obj, _info: isinstance(obj, (cls, model))
 
     # Get type description from either kwargs, or the model's docstring
-    description = kwargs.pop("description", cleandoc(model.__doc__))
+    description = kwargs.pop("description", cleandoc(model.__doc__)) or None
 
     strawberry.type(cls, description=description, **kwargs)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -39,3 +39,14 @@ class Group(models.Model):
 
 class Tag(models.Model):
     name = models.CharField(max_length=50)
+
+
+class Book(models.Model):
+    """Model with lots of extra metadata."""
+
+    title = models.CharField(
+        max_length=20,
+        blank=False,
+        null=False,
+        help_text="The name by which the book is known.",
+    )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,34 @@
+"""
+Tests for `strawberry_django/settings.py`.
+"""
+from django.test import override_settings
+
+from strawberry_django import settings
+
+
+def test_defaults():
+    """
+    Test that `strawberry_django_settings()` provides the default settings if they don't
+    exist in the Django settings file.
+    """
+    assert settings.strawberry_django_settings() == settings.DEFAULT_DJANGO_SETTINGS
+
+
+def test_non_defaults():
+    """
+    Test that `strawberry_django_settings()` provides the user's settings if they are
+    defined in the Django settings file.
+    """
+    with override_settings(
+        STRAWBERRY_DJANGO=settings.StrawberryDjangoSettings(
+            FIELD_DESCRIPTION_FROM_HELP_TEXT=True,
+            TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING=True,
+        )
+    ):
+        assert (
+            settings.strawberry_django_settings()
+            == settings.StrawberryDjangoSettings(
+                FIELD_DESCRIPTION_FROM_HELP_TEXT=True,
+                TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING=True,
+            )
+        )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -110,6 +110,7 @@ def test_field_metadata_overridden():
         Book._type_definition.get_field("title").description == "The name of the story"
     )
 
+
 def test_field_no_empty_strings(monkeypatch: MonkeyPatch):
     """
     Test that an empty Django model docstring doesn't get used for the description.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,4 @@
+from pytest import MonkeyPatch
 from strawberry import auto
 
 import strawberry_django
@@ -108,3 +109,15 @@ def test_field_metadata_overridden():
     assert (
         Book._type_definition.get_field("title").description == "The name of the story"
     )
+
+def test_field_no_empty_strings(monkeypatch: MonkeyPatch):
+    """
+    Test that an empty Django model docstring doesn't get used for the description.
+    """
+    monkeypatch.setattr(BookModel, "__doc__", "")
+
+    @strawberry_django.type(BookModel)
+    class Book:
+        title: auto
+
+    assert Book._type_definition.description is None


### PR DESCRIPTION
## Description

Automatically add Django model docstring and field `help_text` to the Strawberry type description and field descriptions, respectively.

These descriptions can be overridden by passing the `description` kwarg to `strawberry.django.type()` or `strawberry.django.field()`.

Added tests:

- `tests/test_types.py::test_field_metadata_preserved`
- `tests/test_types.py::test_field_metadata_overridden`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
