### PR TITLE
fix: Raise NotImplementedError on unknown Django fields

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -119,7 +119,7 @@ def resolve_model_field_type(model_field, django_type):
     elif django_type.is_input:
         field_type = input_field_type_map.get(model_field_type, None)
     if field_type is None:
-        field_type = field_type_map[model_field_type]
+        field_type = field_type_map.get(model_field_type, NotImplemented)
     if field_type is NotImplemented:
         raise NotImplementedError(
             f"GraphQL type for model field '{model_field}' has not been implemented"

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -359,3 +359,21 @@ def test_type_from_type():
             StrawberryOptional(strawberry_django.ManyToManyInput),
         ),
     ]
+
+
+def test_notimplemented():
+    """Test that an unrecognized field raises `NotImplementedError`."""
+
+    class UnknownField(models.Field):
+        """A field unknown to Strawberry."""
+
+    class UnknownModel(models.Model):
+        """A model with UnknownField."""
+
+        field = UnknownField()
+
+    with pytest.raises(NotImplementedError, match=r"UnknownModel\.field"):
+
+        @strawberry_django.type(UnknownModel)
+        class UnknownType:
+            field: auto


### PR DESCRIPTION
## Description

Ensures that any Django model field that is not recognized by strawberry_django will cause `NotImplementedError` to be raised with a helpful message

This improves the behavior for models using [GeoDjango Spatial Fields](https://docs.djangoproject.com/en/3.2/ref/contrib/gis/model-api/#spatial-field-types), which previously would raise a cryptic `KeyError`.

Added tests:

- `tests/fields/test_types.py::test_notimplemented`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
