### PR TITLE
Fix field ordering inheritance

### DIFF
--- a/docs/references/ordering.md
+++ b/docs/references/ordering.md
@@ -12,3 +12,41 @@ class FruitOrder:
     name: auto
     color: ColorOrder
 ```
+
+The code above generates the following schema:
+
+```graphql
+enum Ordering {
+  ASC
+  DESC
+}
+
+input ColorOrder {
+  name: Ordering
+}
+
+input FruitOrder {
+  name: Ordering
+  color: ColorOrder
+}
+```
+
+## Adding orderings to types
+
+All fields and mutations inherit orderings from the underlying type by default.
+
+```python
+@strawberry.django.type(models.Fruit, order=FruitOrder)
+class Fruit:
+    ...
+```
+
+## Adding orderings directly into a field
+
+Orderings added into a field override the default filters of this type.
+
+```python
+@strawberry.type
+class Query:
+    fruit: Fruit = strawberry.django.field(order=FruitOrder)
+```

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -3,6 +3,7 @@ from typing import List
 import pytest
 import strawberry
 from strawberry import auto
+from strawberry.annotation import StrawberryAnnotation
 
 import strawberry_django
 from tests import models, utils
@@ -20,6 +21,12 @@ class FruitOrder:
     color: ColorOrder
 
 
+@strawberry_django.type(models.Fruit, order=FruitOrder)
+class FruitWithOrder:
+    id: auto
+    name: auto
+
+
 @strawberry.type
 class Query:
     fruits: List[Fruit] = strawberry_django.field(order=FruitOrder)
@@ -28,6 +35,17 @@ class Query:
 @pytest.fixture
 def query():
     return utils.generate_query(Query)
+
+
+def test_field_order_definition():
+    from strawberry_django.fields.field import StrawberryDjangoField
+
+    field = StrawberryDjangoField(type_annotation=StrawberryAnnotation(FruitWithOrder))
+    assert field.get_order() == FruitOrder
+    field = StrawberryDjangoField(
+        type_annotation=StrawberryAnnotation(FruitWithOrder), filters=None
+    )
+    assert field.get_filters() is None
 
 
 def test_asc(query, fruits):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The `@strawberry.django.type` annotion accepts `filters` and `order` parameters, but only `filters` is properly used as a default for fields. This PR fixes the inheritance of the `order` parameter. The code for ordering is based of the existing code for filtering. Additionally, this PR documents this feature similar to the filters documentation.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry-graphql-django/issues/96

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
