### PR TITLE
Broaden is_strawberry_django_field to support custom field classes

### DIFF
--- a/strawberry_django/utils.py
+++ b/strawberry_django/utils.py
@@ -37,9 +37,9 @@ def is_strawberry_field(obj):
 
 
 def is_strawberry_django_field(obj):
-    from strawberry_django.fields.field import StrawberryDjangoField
+    from strawberry_django.fields.field import StrawberryDjangoFieldBase
 
-    return isinstance(obj, StrawberryDjangoField)
+    return isinstance(obj, StrawberryDjangoFieldBase)
 
 
 def is_django_type(obj):


### PR DESCRIPTION
## Description
When:
1. Using a custom field class in a type
2. It's processed by `type.get_field` is called on an instance of a custom field
3. The custom field class's `from_field` wants to replicate similar functionality to `StrawberryDjangoField.from_field`

It will be useful to have the `is_strawberry_django_field` use the `StrawberryDjangoFieldBase` class as it's means of detecting a strawberry-django field class since that will also be used in a custom class.

I don't believe this change will affect any existing usecase

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
