### PR TITLE
import TypedDict from typing_extensions for Python 3.7

### DIFF
--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -1,7 +1,10 @@
 """
 Code for interacting with Django settings.
 """
-from typing import TypedDict
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extension import TypedDict
 
 from django.conf import settings
 

--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -4,7 +4,7 @@ Code for interacting with Django settings.
 try:
     from typing import TypedDict
 except ImportError:
-    from typing_extension import TypedDict
+    from typing_extensions import TypedDict
 
 from django.conf import settings
 


### PR DESCRIPTION
## Description
`from typing import TypedDict` breaks support for Python 3.7, see https://github.com/python/typing_extensions#included-items.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
