### PR TITLE
Allow passing info in filters

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -127,12 +127,9 @@ def build_filter_kwargs(filters):
 def function_allow_passing_info(filter_method: FunctionType) -> bool:
     argspec = inspect.getfullargspec(filter_method)
 
-    if "info" in getattr(argspec, "args", []) or "info" in getattr(
+    return "info" in getattr(argspec, "args", []) or "info" in getattr(
         argspec, "kwargs", []
-    ):
-        return True
-    else:
-        return False
+    )
 
 
 def apply(filters, queryset: QuerySet, info=UNSET, pk=UNSET) -> QuerySet:

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -183,6 +183,7 @@ def test_resolver_filter_with_info(fruits):
 
         def filter_custom_field(self, queryset, info: Info):
             # Test here is to prove that info can be passed properly
+            assert isinstance(info, Info)
             return queryset
 
     @strawberry.type

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -172,6 +172,34 @@ def test_resolver_filter(fruits):
     ]
 
 
+def test_resolver_filter_with_info(fruits):
+    from strawberry.types.info import Info
+
+    @strawberry_django.filters.filter(models.Fruit, lookups=True)
+    class FruitFilterWithInfo:
+        id: auto
+        name: auto
+        custom_field: bool
+
+        def filter_custom_field(self, queryset, info: Info):
+            # Test here is to prove that info can be passed properly
+            return queryset
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def fruits(filters: FruitFilterWithInfo) -> List[Fruit]:
+            queryset = models.Fruit.objects.all()
+            return strawberry_django.filters.apply(filters, queryset)
+
+    query = utils.generate_query(Query)
+    result = query("{ fruits(filters: customField: true }) { id name } }")
+    assert not result.errors
+    assert result.data["fruits"] == [
+        {"id": "1", "name": "strawberry"},
+    ]
+
+
 def test_resolver_nonfilter(fruits):
     @strawberry.type
     class Query:


### PR DESCRIPTION
## Description

This patch allows passing the info object to filters, catering for use cases like filtering with respect to the logged in user (which, its relative cookie will be passed via the input object).

At the same time, it addresses existing codebase and not breaking them by performing analysis on the filter function provided. If the `info` parameter exists, then it is passed. Else not.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes as per discussion here: https://discord.com/channels/689806334337482765/1025667620407619614 
* Personally decided against rewriting a 'resolvers' support code as not only I think it will potentially break more codebase, it will also increase complexity

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
