### PR TITLE
Implementing filter, order and pagination in `StrawberryDjangoField` super classes

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -5,6 +5,7 @@ from strawberry import UNSET
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.field import StrawberryField
 from strawberry.type import StrawberryList, StrawberryOptional
+from strawberry.types import Info
 
 from .. import utils
 from ..filters import StrawberryDjangoFieldFilters
@@ -17,7 +18,7 @@ T = TypeVar("T", bound="StrawberryDjangoFieldBase")
 
 
 class StrawberryDjangoFieldBase:
-    def get_queryset(self, queryset: models.QuerySet, info, **kwargs):
+    def get_queryset(self, queryset: models.QuerySet, info: Info, **kwargs):
         return queryset
 
     @property

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -169,7 +169,7 @@ class StrawberryDjangoFieldFilters:
             return type_._django_type.filters
         return None
 
-    def _apply_filters(
+    def apply_filters(
         self, queryset: QuerySet, filters: Type = UNSET, pk=UNSET
     ) -> QuerySet:
         return apply(filters, queryset, pk)
@@ -178,4 +178,4 @@ class StrawberryDjangoFieldFilters:
         self, queryset: QuerySet, info: Info, pk=UNSET, filters: Type = UNSET, **kwargs
     ):
         queryset = super().get_queryset(queryset, info, **kwargs)
-        return self._apply_filters(queryset, filters, pk)
+        return self.apply_filters(queryset, filters, pk)

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -1,10 +1,12 @@
 from enum import Enum
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, List, Optional, Type, TypeVar
 
 import strawberry
+from django.db.models import QuerySet
 from django.db.models.sql.query import get_field_names_from_opts
 from strawberry import UNSET
 from strawberry.arguments import StrawberryArgument
+from strawberry.types import Info
 
 from . import utils
 from .arguments import argument
@@ -118,7 +120,7 @@ def build_filter_kwargs(filters):
     return filter_kwargs, filter_methods
 
 
-def apply(filters, queryset, pk=UNSET):
+def apply(filters, queryset: QuerySet, pk=UNSET) -> QuerySet:
     if pk is not UNSET:
         queryset = queryset.filter(pk=pk)
 
@@ -158,7 +160,7 @@ class StrawberryDjangoFieldFilters:
                 arguments.append(argument("filters", filters))
         return super().arguments + arguments
 
-    def get_filters(self):
+    def get_filters(self) -> Optional[Type]:
         if self.filters is not UNSET:
             return self.filters
         type_ = utils.unwrap_type(self.type or self.child.type)
@@ -167,6 +169,13 @@ class StrawberryDjangoFieldFilters:
             return type_._django_type.filters
         return None
 
-    def get_queryset(self, queryset, info, pk=UNSET, filters=UNSET, **kwargs):
-        queryset = super().get_queryset(queryset, info, **kwargs)
+    def _apply_filters(
+        self, queryset: QuerySet, filters: Type = UNSET, pk=UNSET
+    ) -> QuerySet:
         return apply(filters, queryset, pk)
+
+    def get_queryset(
+        self, queryset: QuerySet, info: Info, pk=UNSET, filters: Type = UNSET, **kwargs
+    ):
+        queryset = super().get_queryset(queryset, info, **kwargs)
+        return self._apply_filters(queryset, filters, pk)

--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -1,11 +1,14 @@
 import enum
-from typing import List, Optional
+from typing import List, Optional, Type
 
 import strawberry
+from django.db.models import QuerySet
 from strawberry import UNSET
 from strawberry.arguments import StrawberryArgument
+from strawberry.auto import StrawberryAuto
+from strawberry.types import Info
 
-import strawberry_django
+from strawberry_django import fields
 
 from . import utils
 from .arguments import argument
@@ -19,7 +22,7 @@ class Ordering(enum.Enum):
 
 def generate_order_args(order, prefix=""):
     args = []
-    for field in strawberry_django.fields(order):
+    for field in fields(order):
         ordering = getattr(order, field.name, UNSET)
         if ordering is UNSET:
             continue
@@ -36,7 +39,7 @@ def generate_order_args(order, prefix=""):
 def order(model):
     def wrapper(cls):
         for name, type_ in cls.__annotations__.items():
-            if strawberry_django.is_auto(type_):
+            if isinstance(type_, StrawberryAuto):
                 type_ = Ordering
             cls.__annotations__[name] = Optional[type_]
             setattr(cls, name, UNSET)
@@ -45,7 +48,7 @@ def order(model):
     return wrapper
 
 
-def apply(order, queryset):
+def apply(order, queryset: QuerySet) -> QuerySet:
     if order is UNSET or order is None:
         return queryset
     args = generate_order_args(order)
@@ -68,7 +71,7 @@ class StrawberryDjangoFieldOrdering:
                 arguments.append(argument("order", order))
         return super().arguments + arguments
 
-    def get_order(self):
+    def get_order(self) -> Optional[Type]:
         if self.order is not UNSET:
             return self.order
         type_ = utils.unwrap_type(self.type or self.child.type)
@@ -77,6 +80,11 @@ class StrawberryDjangoFieldOrdering:
             return type_._django_type.order
         return None
 
-    def get_queryset(self, queryset, info, order=UNSET, **kwargs):
-        queryset = super().get_queryset(queryset, info, **kwargs)
+    def _apply_order(self, queryset: QuerySet, order) -> QuerySet:
         return apply(order, queryset)
+
+    def get_queryset(
+        self, queryset: QuerySet, info: Info, order: Type = UNSET, **kwargs
+    ):
+        queryset = super().get_queryset(queryset, info, **kwargs)
+        return self._apply_order(queryset, order)

--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -8,7 +8,7 @@ from strawberry.arguments import StrawberryArgument
 from strawberry.auto import StrawberryAuto
 from strawberry.types import Info
 
-from strawberry_django import fields
+from strawberry_django.utils import fields
 
 from . import utils
 from .arguments import argument

--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -80,11 +80,11 @@ class StrawberryDjangoFieldOrdering:
             return type_._django_type.order
         return None
 
-    def _apply_order(self, queryset: QuerySet, order) -> QuerySet:
+    def apply_order(self, queryset: QuerySet, order) -> QuerySet:
         return apply(order, queryset)
 
     def get_queryset(
         self, queryset: QuerySet, info: Info, order: Type = UNSET, **kwargs
     ):
         queryset = super().get_queryset(queryset, info, **kwargs)
-        return self._apply_order(queryset, order)
+        return self.apply_order(queryset, order)

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -48,11 +48,11 @@ class StrawberryDjangoPagination:
             return type_._django_type.pagination
         return None
 
-    def _apply_pagination(self, queryset: QuerySet, pagination):
+    def apply_pagination(self, queryset: QuerySet, pagination=UNSET):
         return apply(pagination, queryset)
 
     def get_queryset(
         self, queryset: QuerySet, info: Info, pagination: Type = UNSET, **kwargs
     ):
         queryset = super().get_queryset(queryset, info, **kwargs)
-        return apply(pagination, queryset)
+        return self.apply_pagination(queryset, pagination)

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -1,8 +1,10 @@
-from typing import List
+from typing import List, Optional, Type
 
 import strawberry
+from django.db.models import QuerySet
 from strawberry import UNSET
 from strawberry.arguments import StrawberryArgument
+from strawberry.types import Info
 
 from . import utils
 from .arguments import argument
@@ -37,7 +39,7 @@ class StrawberryDjangoPagination:
                 arguments.append(argument("pagination", OffsetPaginationInput))
         return super().arguments + arguments
 
-    def get_pagination(self):
+    def get_pagination(self) -> Optional[Type]:
         if self.pagination is not UNSET:
             return self.pagination
 
@@ -46,6 +48,11 @@ class StrawberryDjangoPagination:
             return type_._django_type.pagination
         return None
 
-    def get_queryset(self, queryset, info, pagination=UNSET, **kwargs):
+    def _apply_pagination(self, queryset: QuerySet, pagination):
+        return apply(pagination, queryset)
+
+    def get_queryset(
+        self, queryset: QuerySet, info: Info, pagination: Type = UNSET, **kwargs
+    ):
         queryset = super().get_queryset(queryset, info, **kwargs)
         return apply(pagination, queryset)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

Changed base classes for `StrawberryDjangoField` to allow overloading filter, order and pagination of queryset without too much hassle. If someone were to want to change how filtering works and supply a custom filter type - they'd have to subclass `StrawberryDjangoField` and change the `get_queryset` method which already calls `StrawberryDjangoFieldFilters.get_queryset` which implements the filtering in a unrelated function that cannot be overrwritten - with this change they'd just have to overload `_apply_filters`.

Also added type hints to the methods.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist


- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes. 
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
