### PR TITLE
Pass info for generic filter type

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -146,7 +146,11 @@ def apply(filters, queryset: QuerySet, info=UNSET, pk=UNSET) -> QuerySet:
 
     filter_method = getattr(filters, "filter", None)
     if filter_method:
-        return filter_method(queryset)
+        if function_allow_passing_info(filter_method):
+            return filter_method(queryset=queryset, info=info)
+
+        else:
+            return filter_method(queryset=queryset)
 
     filter_kwargs, filter_methods = build_filter_kwargs(filters)
     queryset = queryset.filter(**filter_kwargs)

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -201,6 +201,33 @@ def test_resolver_filter_with_info(fruits):
     ]
 
 
+def test_resolver_filter_override_with_info(fruits):
+    from strawberry.types.info import Info
+
+    @strawberry_django.filters.filter(models.Fruit, lookups=True)
+    class FruitFilterWithInfo:
+        custom_field: bool
+
+        def filter(self, queryset, info: Info):
+            # Test here is to prove that info can be passed properly
+            assert isinstance(info, Info)
+            return queryset.filter(name="banana")
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def fruits(filters: FruitFilterWithInfo, info: Info) -> List[Fruit]:
+            queryset = models.Fruit.objects.all()
+            return strawberry_django.filters.apply(filters, queryset, info=info)
+
+    query = utils.generate_query(Query)
+    result = query("{ fruits(filters: { customField: true }) { id name } }")
+    assert not result.errors
+    assert result.data["fruits"] == [
+        {"id": "3", "name": "banana"},
+    ]
+
+
 def test_resolver_nonfilter(fruits):
     @strawberry.type
     class Query:


### PR DESCRIPTION
## Description
Continuing:
- https://github.com/strawberry-graphql/strawberry-graphql-django/pull/191

This patch allows passing info into overridden 'filter' function.


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
