### PR TITLE
Updates documentation for `get_queryset`

### DIFF
--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -73,16 +73,17 @@ see the [Fields](fields.md) documentation.
 ### `QuerySet` setup
 
 By default, a `strawberry_django` type will get data from the default manager for its Django Model.
-You can implement a custom `get_queryset` to your type to do some extra processing to the default queryset,
+You can implement a custom `get_queryset` class method to your type to do some extra processing to the default queryset,
 like filtering it further.
 
-> Warning! This function is no longer a classmethod as of release: [`0.5.4`](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4). Previously, the method signature looked like: `get_queryset(cls, queryset, info):`.
+> **Warning** This function was implemented as an instance method prior to release: [`0.5.4`](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4). Previously, the method signature looked like: `get_queryset(self, queryset, info):` It has since changed to a class method.
 
 ```python
 @strawberry.django.type(models.Fruit)
 class Berry:
 
-    def get_queryset(queryset, info):
+    @classmethod
+    def get_queryset(cls, queryset, info):
         return queryset.filter(name__contains="berry")
 ```
 

--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -76,7 +76,7 @@ By default, a `strawberry_django` type will get data from the default manager fo
 You can implement a custom `get_queryset` classmethod to your type to do some extra processing to the default queryset,
 like filtering it further.
 
-> **Warning** This function was implemented as an instance method prior to release: [`0.5.4`](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4). Previously, the method signature looked like: `get_queryset(self, queryset, info):` It has since changed to a class method.
+> **Warning** This function was improperly documented prior to release: [`0.5.4`](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4). Previously, the method signature was documented as: `get_queryset(self, queryset, info):` It has since changed.
 
 ```python
 @strawberry.django.type(models.Fruit)
@@ -97,7 +97,8 @@ limit access to results based on the current user in the request:
 @strawberry.django.type(models.Fruit)
 class Berry:
 
-    def get_queryset(queryset, info):
+    @classmethod
+    def get_queryset(cls, queryset, info):
         if not info.context.request.user.is_staff:
             # Restrict access to top secret berries if the user is not a staff member
             queryset = queryset.filter(is_top_secret=False)

--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -76,7 +76,7 @@ By default, a `strawberry_django` type will get data from the default manager fo
 You can implement a custom `get_queryset` to your type to do some extra processing to the default queryset,
 like filtering it further.
 
-> Warning! The `self` parameter was removed in version: [`0.5.4`](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4). Previously, the method signature looked like: `get_queryset(self, queryset, info):`.
+> Warning! This function is no longer a classmethod as of release: [`0.5.4`](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4). Previously, the method signature looked like: `get_queryset(cls, queryset, info):`.
 
 ```python
 @strawberry.django.type(models.Fruit)

--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -73,7 +73,7 @@ see the [Fields](fields.md) documentation.
 ### `QuerySet` setup
 
 By default, a `strawberry_django` type will get data from the default manager for its Django Model.
-You can implement a custom `get_queryset` class method to your type to do some extra processing to the default queryset,
+You can implement a custom `get_queryset` classmethod to your type to do some extra processing to the default queryset,
 like filtering it further.
 
 > **Warning** This function was implemented as an instance method prior to release: [`0.5.4`](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4). Previously, the method signature looked like: `get_queryset(self, queryset, info):` It has since changed to a class method.

--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -87,7 +87,7 @@ class Berry:
         return queryset.filter(name__contains="berry")
 ```
 
-The `get_queryset` method is given a `QuerySet` to filter and
+The `get_queryset` classmethod is given a `QuerySet` to filter and
 a `strawberry` `Info` object containing details about the request.
 
 You can use that `info` parameter to, for example,

--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -76,11 +76,13 @@ By default, a `strawberry_django` type will get data from the default manager fo
 You can implement a custom `get_queryset` to your type to do some extra processing to the default queryset,
 like filtering it further.
 
+> Warning! The `self` parameter was removed in version: [`0.5.4`](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4). Previously, the method signature looked like: `get_queryset(self, queryset, info):`.
+
 ```python
 @strawberry.django.type(models.Fruit)
 class Berry:
 
-    def get_queryset(self, queryset, info):
+    def get_queryset(queryset, info):
         return queryset.filter(name__contains="berry")
 ```
 
@@ -94,7 +96,7 @@ limit access to results based on the current user in the request:
 @strawberry.django.type(models.Fruit)
 class Berry:
 
-    def get_queryset(self, queryset, info):
+    def get_queryset(queryset, info):
         if not info.context.request.user.is_staff:
             # Restrict access to top secret berries if the user is not a staff member
             queryset = queryset.filter(is_top_secret=False)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR updates the relevent documentation for the removal of the `self` argument in `get_queryset` for [Release 0.5.4](https://github.com/strawberry-graphql/strawberry-graphql-django/releases/tag/v0.5.4)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR
N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
