### PR TITLE
make pk argument required when querying single object

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -182,7 +182,7 @@ class StrawberryDjangoFieldFilters:
             filters = self.get_filters()
             if self.django_model and not self.is_list:
                 if self.is_relation is False:
-                    arguments.append(argument("pk", strawberry.ID))
+                    arguments.append(argument("pk", strawberry.ID, is_optional=False))
             elif filters and filters is not UNSET:
                 arguments.append(argument("filters", filters))
         return super().arguments + arguments

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 import strawberry
+from graphql import GraphQLError
 from strawberry import auto
 
 import strawberry_django
@@ -80,6 +81,15 @@ async def test_single(query, users):
 
     assert not result.errors
     assert result.data["user"] == {"name": users[0].name}
+
+
+async def test_required_pk_single(query, users):
+    result = await query("{ user { name } }")
+
+    assert bool(result.errors)
+    assert len(result.errors) == 1
+    assert isinstance(result.errors[0], GraphQLError)
+    assert result.errors[0].message == "Field 'user' argument 'pk' of type 'ID!' is required, but it was not provided."
 
 
 async def test_many(query, users):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -89,7 +89,8 @@ async def test_required_pk_single(query, users):
     assert bool(result.errors)
     assert len(result.errors) == 1
     assert isinstance(result.errors[0], GraphQLError)
-    assert result.errors[0].message == "Field 'user' argument 'pk' of type 'ID!' is required, but it was not provided."
+    assert result.errors[0].message == "Field 'user' argument 'pk' of type 'ID!' is " \
+                                       "required, but it was not provided."
 
 
 async def test_many(query, users):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -89,8 +89,10 @@ async def test_required_pk_single(query, users):
     assert bool(result.errors)
     assert len(result.errors) == 1
     assert isinstance(result.errors[0], GraphQLError)
-    assert result.errors[0].message == "Field 'user' argument 'pk' of type 'ID!' is " \
-                                       "required, but it was not provided."
+    assert (
+        result.errors[0].message == "Field 'user' argument 'pk' of type 'ID!' is "
+        "required, but it was not provided."
+    )
 
 
 async def test_many(query, users):


### PR DESCRIPTION
It's just a one line correction to make pk argument required when querying a single django object

edit: and test fot required pk argument