### PR TITLE
refactor: do not insert `pk` arguments inside non root fields

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -185,10 +185,7 @@ class StrawberryDjangoFieldFilters:
             if (
                 self.django_model
                 and not self.is_list
-                and (
-                    self.origin._type_definition.name
-                    in ["Query", "Mutation", "Subscription"]
-                )
+                and self.origin._type_definition.name == "Query"
             ):
                 arguments.append(argument("pk", strawberry.ID, is_optional=False))
             elif filters and filters is not UNSET:

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -182,9 +182,15 @@ class StrawberryDjangoFieldFilters:
         arguments = []
         if not self.base_resolver:
             filters = self.get_filters()
-            if self.django_model and not self.is_list:
-                if self.is_relation is False:
-                    arguments.append(argument("pk", strawberry.ID, is_optional=False))
+            if (
+                self.django_model
+                and not self.is_list
+                and (
+                    self.origin._type_definition.name
+                    in ["Query", "Mutation", "Subscription"]
+                )
+            ):
+                arguments.append(argument("pk", strawberry.ID, is_optional=False))
             elif filters and filters is not UNSET:
                 arguments.append(argument("filters", filters))
         return super().arguments + arguments

--- a/tests/models.py
+++ b/tests/models.py
@@ -32,6 +32,13 @@ class User(models.Model):
     )
     tag = models.OneToOneField("Tag", null=True, on_delete=models.CASCADE)
 
+    @property
+    def group_prop(self) -> "Group":
+        return self.group
+
+    def get_group(self) -> "Group":
+        return self.group
+
 
 class Group(models.Model):
     name = models.CharField(max_length=50)


### PR DESCRIPTION
Instead of checking if the field is a relation or not, just check if
it is defined in a root type (e.g. a `Query`). If it is not, do not
insert the pk argument for it.

This fixes a lot of issues like:

1) Defining a field with a name different from the relation
2) Defining a field for a function or property inside the model
3) etc

Fix #215
Fix #235
Fix #245
