### PR TITLE
feat: enum integration

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -217,6 +217,21 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-choices-field"
+version = "2.2.2"
+description = "Django field that set/get django's new TextChoices/IntegerChoices enum."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "django_choices_field-2.2.2-py3-none-any.whl", hash = "sha256:bfdf5a8e098ead77eb1d5e32a85352af4a37a7b3f28fb5e74b8a17c1270a30bc"},
+    {file = "django_choices_field-2.2.2.tar.gz", hash = "sha256:1147a47d3972a49479be002c5c8ad0118863a8b936933597cfb3d8fcf257a578"},
+]
+
+[package.dependencies]
+django = ">=3.2"
+typing_extensions = ">=4.0.0"
+
+[[package]]
 name = "django-debug-toolbar"
 version = "3.8.1"
 description = "A configurable set of panels that display various debug information about the current request/response."
@@ -1156,13 +1171,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.6.3"
+version = "4.7.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
-    {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
+    {file = "typing_extensions-4.7.0-py3-none-any.whl", hash = "sha256:5d8c9dac95c27d20df12fb1d97b9793ab8b2af8a3a525e68c80e21060c161771"},
+    {file = "typing_extensions-4.7.0.tar.gz", hash = "sha256:935ccf31549830cda708b42289d44b6f74084d616a00be651601a4f968e77c82"},
 ]
 
 [[package]]
@@ -1273,8 +1288,9 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [extras]
 debug-toolbar = ["django-debug-toolbar"]
+enum = ["django-choices-field"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "ebc1cf469c2634b2fa4702036dd9a73d7258f2fcf21f062227503ba32a599b8e"
+content-hash = "1dbafab68956539efb7fa7f604c5d5a1c58338091b660d0b428b881a5c4b634c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ python = ">=3.7,<4.0"
 Django = ">=3.2"
 strawberry-graphql = ">=0.190.0"
 django-debug-toolbar = { version = ">=3.4", optional = true }
+django-choices-field = { version = ">=2.2.2", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.21.0"
@@ -41,6 +42,7 @@ pytest-pythonpath = "^0.7.3"
 pytest-watch = "^4.2.0"
 pytest-mock = "^3.5.1"
 django-debug-toolbar = "^3.2.4"
+django-choices-field = "^2.2.2"
 mkdocs = "^1.4.2"
 mkdocs-markdownextradata-plugin = "^0.2.5"
 mkdocs-material = "^9.0.4"
@@ -53,6 +55,7 @@ factory-boy = "^3.2.1"
 
 [tool.poetry.extras]
 debug-toolbar = ["django-debug-toolbar"]
+enum = ["django-choices-field"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "setuptools"]

--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -13,18 +13,23 @@ class StrawberryDjangoSettings(TypedDict):
     defined in `DEFAULT_DJANGO_SETTINGS`.
     """
 
+    #: If True, field descriptions will be fetched from the
+    #: corresponding model field's `help_text` attribute.
     FIELD_DESCRIPTION_FROM_HELP_TEXT: bool
-    """(Default: False) If True, field descriptions will be fetched from the
-    corresponding model field's `help_text` attribute."""
 
+    #: If True, type descriptions will be fetched from the
+    #: corresponding model model's docstring.
     TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING: bool
-    """(Default: False) If True, type descriptions will be fetched from the
-    corresponding model's docstring."""
+
+    #: If True, fields with `choices` will have automatically generate
+    #: an enum of possibilities instead of being exposed as `String`
+    GENERATE_ENUMS_FROM_CHOICES: bool
 
 
 DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
     FIELD_DESCRIPTION_FROM_HELP_TEXT=False,
     TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING=False,
+    GENERATE_ENUMS_FROM_CHOICES=False,
 )
 
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,159 @@
+import textwrap
+from typing import cast
+
+import strawberry
+import strawberry.django
+from django.db import models
+from django.test import override_settings
+from django_choices_field import TextChoicesField
+from pytest_mock import MockerFixture
+
+from strawberry_django.fields import types
+from strawberry_django.fields.types import field_type_map
+from strawberry_django.settings import (
+    strawberry_django_settings,
+)
+
+
+class Choice(models.TextChoices):
+    """Choice description."""
+
+    A = "a", "A description"
+    B = "b", "B description"
+    C = "c", "C description"
+
+
+class ChoicesModel(models.Model):
+    attr1 = TextChoicesField(choices_enum=Choice)
+    attr2 = models.CharField(
+        max_length=255,
+        choices=[
+            ("c", "C description"),
+            ("d", "D description"),
+        ],
+    )
+
+
+def test_choices_field():
+    @strawberry.django.type(ChoicesModel)
+    class ChoicesType:
+        attr1: strawberry.auto
+        attr2: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        @strawberry.django.field
+        def obj(self) -> ChoicesType:
+            return cast(ChoicesType, ChoicesModel(attr1=Choice.A, attr2="c"))
+
+    expected = """\
+    enum Choice {
+      A
+      B
+      C
+    }
+
+    type ChoicesType {
+      attr1: Choice!
+      attr2: String!
+    }
+
+    type Query {
+      obj: ChoicesType!
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+    assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()
+
+    result = schema.execute_sync("query { obj { attr1, attr2 }}")
+    assert result.errors is None
+    assert result.data == {"obj": {"attr1": "A", "attr2": "c"}}
+
+
+def test_no_choices_enum(mocker: MockerFixture):
+    # We can't use patch with the module name directly as it tries to resolve
+    # strawberry.fields as a function instead of the module for python versions
+    # before 3.11
+    mocker.patch.object(types, "TextChoicesField", None)
+    mocker.patch.dict(field_type_map, {TextChoicesField: str})
+
+    @strawberry.django.type(ChoicesModel)
+    class ChoicesType:
+        attr1: strawberry.auto
+        attr2: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        @strawberry.django.field
+        def obj(self) -> ChoicesType:
+            return cast(ChoicesType, ChoicesModel(attr1=Choice.A, attr2="c"))
+
+    expected = """\
+    type ChoicesType {
+      attr1: String!
+      attr2: String!
+    }
+
+    type Query {
+      obj: ChoicesType!
+    }
+    """
+
+    schema = strawberry.Schema(query=Query)
+    assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()
+
+    result = schema.execute_sync("query { obj { attr1, attr2 }}")
+    assert result.errors is None
+    assert result.data == {"obj": {"attr1": "a", "attr2": "c"}}
+
+
+@override_settings(
+    STRAWBERRY_DJANGO={
+        **strawberry_django_settings(),
+        "GENERATE_ENUMS_FROM_CHOICES": True,
+    },
+)
+def test_generate_choices_from_enum():
+    @strawberry.django.type(ChoicesModel)
+    class ChoicesType:
+        attr1: strawberry.auto
+        attr2: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        @strawberry.django.field
+        def obj(self) -> ChoicesType:
+            return cast(ChoicesType, ChoicesModel(attr1=Choice.A, attr2="c"))
+
+    expected = '''\
+    enum Choice {
+      A
+      B
+      C
+    }
+
+    type ChoicesType {
+      attr1: Choice!
+      attr2: TestsChoicesModelAttr2Enum!
+    }
+
+    type Query {
+      obj: ChoicesType!
+    }
+
+    enum TestsChoicesModelAttr2Enum {
+      """C description"""
+      c
+
+      """D description"""
+      d
+    }
+    '''
+
+    schema = strawberry.Schema(query=Query)
+    assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()
+
+    result = schema.execute_sync("query { obj { attr1, attr2 }}")
+    assert result.errors is None
+    assert result.data == {"obj": {"attr1": "A", "attr2": "c"}}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,6 +23,7 @@ def test_non_defaults():
         STRAWBERRY_DJANGO=settings.StrawberryDjangoSettings(
             FIELD_DESCRIPTION_FROM_HELP_TEXT=True,
             TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING=True,
+            GENERATE_ENUMS_FROM_CHOICES=False,
         ),
     ):
         assert (
@@ -30,5 +31,6 @@ def test_non_defaults():
             == settings.StrawberryDjangoSettings(
                 FIELD_DESCRIPTION_FROM_HELP_TEXT=True,
                 TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING=True,
+                GENERATE_ENUMS_FROM_CHOICES=False,
             )
         )


### PR DESCRIPTION
feat: enum integration

This enables exposing fields with choices in 2 ways, ported from strawberry-django-plus:

1. It integrates with [django-choices-field](https://github.com/bellini666/django-choices-field)
   to be able to handle the enum itself that already exists

2. It can optionally auto generate an enum from a field's `choices`
   attribute.

Fix #65
Fix #66
