### PR TITLE
Handle Django GENERATE_ENUMS_FROM_CHOICES with strawberry.auto

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -435,7 +435,7 @@ def resolve_model_field_type(
     elif (
         settings["GENERATE_ENUMS_FROM_CHOICES"]
         and isinstance(model_field, Field)
-        and hasattr(model_field, "choices")
+        and getattr(model_field, "choices", None)
     ):
         choices = cast(List[Tuple[Any, str]], model_field.choices)
         field_type = getattr(model_field, "_strawberry_enum", None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It seems that `GENERATE_ENUMS_FROM_CHOICES` breaks `strawberry.auto` types with this error:

```
TypeError: DjangoModelStrawberryType fields cannot be resolved. 'NoneType' object is not iterable
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
