### PR TITLE
Remove usage of `concrete_of`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1329,13 +1329,13 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.193.0"
+version = "0.194.0"
 description = "A library for creating GraphQL APIs"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "strawberry_graphql-0.193.0-py3-none-any.whl", hash = "sha256:072997e654dde90356607dc49be35a310d1c134b95ef9e7a657277f2336a47b5"},
-    {file = "strawberry_graphql-0.193.0.tar.gz", hash = "sha256:4171ccac21fade71106d70c539d0f92a1303b34e9aa57d0cf47bb323ef45c7be"},
+    {file = "strawberry_graphql-0.194.0-py3-none-any.whl", hash = "sha256:f9993f1afacec0f32188acc65410ed9d3bac7832c49905f73430f53697274f68"},
+    {file = "strawberry_graphql-0.194.0.tar.gz", hash = "sha256:a92ffad08afec722a5dd43565e5402de58588df6b59bd486e615e264fbff8dc4"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1329,13 +1329,13 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.194.0"
+version = "0.194.1"
 description = "A library for creating GraphQL APIs"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "strawberry_graphql-0.194.0-py3-none-any.whl", hash = "sha256:f9993f1afacec0f32188acc65410ed9d3bac7832c49905f73430f53697274f68"},
-    {file = "strawberry_graphql-0.194.0.tar.gz", hash = "sha256:a92ffad08afec722a5dd43565e5402de58588df6b59bd486e615e264fbff8dc4"},
+    {file = "strawberry_graphql-0.194.1-py3-none-any.whl", hash = "sha256:e487d67df527331a239a5fa07de1698e63dae06d950961b01f4bb3c7f1e7bc3f"},
+    {file = "strawberry_graphql-0.194.1.tar.gz", hash = "sha256:356fc4ab76e16724c6c4278b7d8fac6a8cad904ea8a907a439ba7329b0d5bf51"},
 ]
 
 [package.dependencies]
@@ -1497,4 +1497,4 @@ enum = ["django-choices-field"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "792555a4ec75609f562be9e4ddeb851e37b02093bff3f857e195acc0117d411d"
+content-hash = "37443400059725b4ab1183cc8770d9aae96d0a10170ce13cc33ec8eee06f77d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 Django = ">=3.2"
-strawberry-graphql = ">=0.192.1"
+strawberry-graphql = ">=0.194.1"
 django-debug-toolbar = { version = ">=3.4", optional = true }
 django-choices-field = { version = ">=2.2.2", optional = true }
 

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -70,12 +70,16 @@ class StrawberryDjangoFieldBase(StrawberryField):
         origin = self.type
 
         object_definition = get_object_definition(origin)
+
         if (
             object_definition
-            and object_definition.concrete_of
-            and issubclass(object_definition.concrete_of.origin, relay.Connection)
+            and issubclass(object_definition.origin, relay.Connection)
         ):
-            origin = object_definition.type_var_map[cast(TypeVar, relay.NodeType)]
+            origin = object_definition.type_var_map.get(cast(TypeVar, relay.NodeType))
+
+            if origin is None:
+                origin = object_definition.specialized_type_var_map[cast(TypeVar, relay.NodeType)]
+
             if isinstance(origin, LazyType):
                 origin = origin.resolve_type()
 

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -75,9 +75,11 @@ class StrawberryDjangoFieldBase(StrawberryField):
             origin = object_definition.type_var_map.get(cast(TypeVar, relay.NodeType))
 
             if origin is None:
-                origin = object_definition.specialized_type_var_map[
-                    cast(TypeVar, relay.NodeType)
-                ]
+                specialized_type_var_map = (
+                    object_definition.specialized_type_var_map or {}
+                )
+
+                origin = specialized_type_var_map[cast(TypeVar, relay.NodeType)]
 
             if isinstance(origin, LazyType):
                 origin = origin.resolve_type()

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -71,14 +71,13 @@ class StrawberryDjangoFieldBase(StrawberryField):
 
         object_definition = get_object_definition(origin)
 
-        if (
-            object_definition
-            and issubclass(object_definition.origin, relay.Connection)
-        ):
+        if object_definition and issubclass(object_definition.origin, relay.Connection):
             origin = object_definition.type_var_map.get(cast(TypeVar, relay.NodeType))
 
             if origin is None:
-                origin = object_definition.specialized_type_var_map[cast(TypeVar, relay.NodeType)]
+                origin = object_definition.specialized_type_var_map[
+                    cast(TypeVar, relay.NodeType)
+                ]
 
             if isinstance(origin, LazyType):
                 origin = origin.resolve_type()

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -326,9 +326,9 @@ def _get_model_hints(
 
         n_type = object_definition.type_var_map.get(cast(TypeVar, relay.NodeType))
         if n_type is None:
-            n_type = object_definition.specialized_type_var_map[
-                cast(TypeVar, relay.NodeType)
-            ]
+            specialized_type_var_map = object_definition.specialized_type_var_map or {}
+
+            n_type = specialized_type_var_map[cast(TypeVar, relay.NodeType)]
         if isinstance(n_type, LazyType):
             n_type = n_type.resolve_type()
 

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -314,8 +314,8 @@ def _get_model_hints(
 
     # In case this is a relay field, find the selected edges/nodes, the selected fields
     # are actually inside edges -> node selection...
-    if object_definition.concrete_of and issubclass(
-        object_definition.concrete_of.origin,
+    if issubclass(
+        object_definition.origin,
         relay.Connection,
     ):
         # TODO: Connections are mostly used for pagination so it doesn't make sense for
@@ -324,7 +324,11 @@ def _get_model_hints(
         if level > 0:
             return None
 
-        n_type = object_definition.type_var_map[cast(TypeVar, relay.NodeType)]
+        n_type = object_definition.type_var_map.get(cast(TypeVar, relay.NodeType))
+        if n_type is None:
+            n_type = object_definition.specialized_type_var_map[
+                cast(TypeVar, relay.NodeType)
+            ]
         if isinstance(n_type, LazyType):
             n_type = n_type.resolve_type()
 

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -41,6 +41,8 @@ from .models import (
 UserModel = cast(Type[AbstractUser], get_user_model())
 
 
+
+
 @strawberry_django.type(UserModel)
 class UserType(relay.Node):
     username: relay.NodeID[str]
@@ -236,6 +238,10 @@ class MilestoneInput:
 class MilestoneInputPartial(NodeInputPartial):
     name: strawberry.auto
 
+@strawberry.type
+class ProjectConnection(ListConnectionWithTotalCount[ProjectType]):
+    """Project connection documentation."""
+
 
 @strawberry.type
 class Query:
@@ -280,7 +286,7 @@ class Query:
         strawberry_django.connection()
     )
 
-    project_conn: ListConnectionWithTotalCount[ProjectType] = (
+    project_conn: ProjectConnection = (
         strawberry_django.connection()
     )
     tag_conn: ListConnectionWithTotalCount[TagType] = strawberry_django.connection()

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -41,8 +41,6 @@ from .models import (
 UserModel = cast(Type[AbstractUser], get_user_model())
 
 
-
-
 @strawberry_django.type(UserModel)
 class UserType(relay.Node):
     username: relay.NodeID[str]
@@ -77,6 +75,7 @@ class StaffType(relay.Node):
 class ProjectFilter:
     name: strawberry.auto
     due_date: strawberry.auto
+
 
 @strawberry_django.type(Project, filters=ProjectFilter)
 class ProjectType(relay.Node):
@@ -243,6 +242,7 @@ class MilestoneInput:
 class MilestoneInputPartial(NodeInputPartial):
     name: strawberry.auto
 
+
 @strawberry.type
 class ProjectConnection(ListConnectionWithTotalCount[ProjectType]):
     """Project connection documentation."""
@@ -291,9 +291,7 @@ class Query:
         strawberry_django.connection()
     )
 
-    project_conn: ProjectConnection = (
-        strawberry_django.connection()
-    )
+    project_conn: ProjectConnection = strawberry_django.connection()
     tag_conn: ListConnectionWithTotalCount[TagType] = strawberry_django.connection()
     staff_conn: ListConnectionWithTotalCount[StaffType] = strawberry_django.connection()
 

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -350,7 +350,7 @@ class Query:
 
         return cast(UserType, user)
 
-    @strawberry_django.connection(ListConnectionWithTotalCount[ProjectType])
+    @strawberry_django.connection(ProjectConnection)
     def project_conn_with_resolver(self, root: str, name: str) -> Iterable[Project]:
         return Project.objects.filter(name__contains=name)
 

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -73,7 +73,12 @@ class StaffType(relay.Node):
         return queryset.filter(is_staff=True)
 
 
-@strawberry_django.type(Project)
+@strawberry_django.filter(Project, lookups=True)
+class ProjectFilter:
+    name: strawberry.auto
+    due_date: strawberry.auto
+
+@strawberry_django.type(Project, filters=ProjectFilter)
 class ProjectType(relay.Node):
     name: strawberry.auto
     due_date: strawberry.auto

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -371,6 +371,17 @@ type PageInfo {
   endCursor: String
 }
 
+type ProjectConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ProjectTypeEdge!]!
+
+  """Total quantity of existing nodes."""
+  totalCount: Int
+}
+
 input ProjectInputPartial {
   id: GlobalID
   name: String
@@ -517,7 +528,7 @@ type Query {
 
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
-  ): ProjectTypeConnection!
+  ): ProjectConnection!
   tagConn(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -105,6 +105,26 @@ union CreateQuizPayload = QuizType | OperationInfo
 """Date (isoformat)"""
 scalar Date
 
+input DateFilterLookup {
+  exact: Date
+  iExact: Date
+  contains: Date
+  iContains: Date
+  inList: [Date!]
+  gt: Date
+  gte: Date
+  lt: Date
+  lte: Date
+  startsWith: Date
+  iStartsWith: Date
+  endsWith: Date
+  iEndsWith: Date
+  range: [Date!]
+  isNull: Boolean
+  regex: String
+  iRegex: String
+}
+
 """Date with time (isoformat)"""
 scalar DateTime
 
@@ -382,6 +402,11 @@ type ProjectConnection {
   totalCount: Int
 }
 
+input ProjectFilter {
+  name: StrFilterLookup
+  dueDate: DateFilterLookup
+}
+
 input ProjectInputPartial {
   id: GlobalID
   name: String
@@ -460,7 +485,7 @@ type Query {
   ): [StaffType]!
   issueList: [IssueType!]!
   milestoneList(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
-  projectList: [ProjectType!]!
+  projectList(filters: ProjectFilter): [ProjectType!]!
   tagList: [TagType!]!
   favoriteConn(
     """Returns the items in the list that come before the specified cursor."""
@@ -505,6 +530,8 @@ type Query {
     last: Int = null
   ): MilestoneTypeConnection!
   projectConn(
+    filters: ProjectFilter
+
     """Returns the items in the list that come before the specified cursor."""
     before: String = null
 
@@ -614,6 +641,7 @@ type Query {
   me: UserType
   projectConnWithResolver(
     name: String!
+    filters: ProjectFilter
 
     """Returns the items in the list that come before the specified cursor."""
     before: String = null

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -402,18 +402,6 @@ type ProjectType implements Node {
   cost: Decimal @isAuthenticated
 }
 
-"""A connection to a list of items."""
-type ProjectTypeConnection {
-  """Pagination data for this connection"""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection"""
-  edges: [ProjectTypeEdge!]!
-
-  """Total quantity of existing nodes."""
-  totalCount: Int
-}
-
 """An edge in a connection."""
 type ProjectTypeEdge {
   """A cursor for use in pagination"""
@@ -638,7 +626,7 @@ type Query {
 
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
-  ): ProjectTypeConnection!
+  ): ProjectConnection!
 }
 
 type QuizType implements Node {

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -537,6 +537,9 @@ def test_query_connection_with_resolver(db, gql_client: GraphQLTestClient):
             node {
               id
               name
+              milestones {
+                id
+              }
             }
           }
         }
@@ -549,14 +552,14 @@ def test_query_connection_with_resolver(db, gql_client: GraphQLTestClient):
     for i in range(10):
         ProjectFactory.create(name=f"Project {i}")
 
-    with assert_num_queries(2):
+    with assert_num_queries(3 if DjangoOptimizerExtension.enabled.get() else 5):
         res = gql_client.query(query)
 
     assert res.data == {
         "projectConnWithResolver": {
             "totalCount": 3,
             "edges": [
-                {"node": {"id": to_base64("ProjectType", p.id), "name": p.name}}
+                {"node": {"id": to_base64("ProjectType", p.id), 'milestones': [], "name": p.name}}
                 for p in [p1, p2, p3]
             ],
         },

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -564,7 +564,7 @@ def test_query_connection_with_resolver(db, gql_client: GraphQLTestClient):
                         "id": to_base64("ProjectType", p.id),
                         "milestones": [],
                         "name": p.name,
-                    }
+                    },
                 }
                 for p in [p1, p2, p3]
             ],

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -559,7 +559,13 @@ def test_query_connection_with_resolver(db, gql_client: GraphQLTestClient):
         "projectConnWithResolver": {
             "totalCount": 3,
             "edges": [
-                {"node": {"id": to_base64("ProjectType", p.id), 'milestones': [], "name": p.name}}
+                {
+                    "node": {
+                        "id": to_base64("ProjectType", p.id),
+                        "milestones": [],
+                        "name": p.name,
+                    }
+                }
                 for p in [p1, p2, p3]
             ],
         },


### PR DESCRIPTION
This PR removes the usage of `concrete_of`, which was causing issues when 
using specialized types, like this:

```python
import strawberry
from strawberry import Schema
from strawberry.extensions import FieldExtension
from strawberry.field import StrawberryField
from typing import Generic, TypeVar

T = TypeVar("T")


class CheckAtRuntime(FieldExtension):
    def apply(self, field: StrawberryField) -> None:
        print('concrete_of when applying extension is', field.type.__strawberry_definition__.concrete_of)

    def resolve(self, next_, source, info, **kwargs):
        return next_(source, info, **kwargs)


@strawberry.type
class MyGenericType(Generic[T]):
    my_value: T


@strawberry.type
class MyConcreteType(MyGenericType[int]):
    pass


@strawberry.type
class Query:
    @strawberry.field(extensions=[CheckAtRuntime()])
    def my_concrete_type(self) -> MyConcreteType:
        return MyConcreteType(my_value=123)


schema = Schema(query=Query)
print('concrete_of when booting is', MyConcreteType.__strawberry_definition__.concrete_of)
```


this was affecting the creation of connections with filters and also the optimizer
