### PR TITLE
Add new keywords "fields" and "exclude" to type decorator for auto-population of Django model fields

### DIFF
--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -122,7 +122,7 @@ strawberry_django.field_type_map.update({
 
     These new keywords should be used with caution, as they may inadvertently lead to exposure of unwanted data. Especially with `fields="__all__"` or `exclude`, sensitive model attributes may be included and made available in the schema without your awareness.
 
-`strawberry.django.type` includes two optional keyword fields to help you more easily populate fields from the Django model, `fields` and `exclude`.
+`strawberry.django.type` includes two optional keyword fields to help you populate fields from the Django model, `fields` and `exclude`.
 
 Valid values for `fields` are:
 

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -122,8 +122,8 @@ strawberry_django.field_type_map.update({
 
 Valid values for `fields` are:
 
-  * `__all__` to assign `strawberry.auto` as the field type for all model fields.
-  * `[<List of field names>]` to assign `strawberry.auto` as the field type for the enumerated fields. These can be combined with manual type annotations if needed.
+- `__all__` to assign `strawberry.auto` as the field type for all model fields.
+- `[<List of field names>]` to assign `strawberry.auto` as the field type for the enumerated fields. These can be combined with manual type annotations if needed.
 
 ```{.python title=fields_all.py}
 @strawberry.django.type(models.Fruit, fields="__all__")
@@ -145,7 +145,7 @@ class FruitType:
 
 Valid values for `exclude` are:
 
-  * `[<List of field names>]` to exclude from the fields list. All other Django model fields will included and have `strawberry.auto` as the field type. These can also be overriden if another field type should be assigned. An empty list is ignored.
+- `[<List of field names>]` to exclude from the fields list. All other Django model fields will included and have `strawberry.auto` as the field type. These can also be overriden if another field type should be assigned. An empty list is ignored.
 
 ```{.python title=exclude.py}
 @strawberry.django.type(models.Fruit, exclude=["name"])

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -159,7 +159,7 @@ class FruitType:
     color: int
 ```
 
-Note that if `fields` has precedence over `exclude`, so if both are provided, then `exclude` is ignored.
+Note that `fields` has precedence over `exclude`, so if both are provided, then `exclude` is ignored.
 
 ## Overriding the field class (advanced)
 

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -120,7 +120,7 @@ strawberry_django.field_type_map.update({
 
 !!! warning
 
-    These new keywords should be used with caution, as they may inadvertently lead to exposure of unwanted data. Especially with `fields="__all__"` or `exclude`, sensitive model attributes may be included and made available without your awareness.
+    These new keywords should be used with caution, as they may inadvertently lead to exposure of unwanted data. Especially with `fields="__all__"` or `exclude`, sensitive model attributes may be included and made available in the schema without your awareness.
 
 `strawberry.django.type` includes two optional keyword fields to help you more easily populate fields from the Django model, `fields` and `exclude`.
 

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -118,6 +118,10 @@ strawberry_django.field_type_map.update({
 
 ## Including / excluding Django model fields by name
 
+!!! warning
+
+    These new keywords should be used with caution, as they may inadvertently lead to exposure of unwanted data. Especially with `fields="__all__"` or `exclude`, sensitive model attributes may be included and made available without your awareness.
+
 `strawberry.django.type` includes two optional keyword fields to help you more easily populate fields from the Django model, `fields` and `exclude`.
 
 Valid values for `fields` are:
@@ -125,19 +129,19 @@ Valid values for `fields` are:
 - `__all__` to assign `strawberry.auto` as the field type for all model fields.
 - `[<List of field names>]` to assign `strawberry.auto` as the field type for the enumerated fields. These can be combined with manual type annotations if needed.
 
-```{.python title=fields_all.py}
+```{.python title="All Fields"}
 @strawberry.django.type(models.Fruit, fields="__all__")
 class FruitType:
     pass
 ```
 
-```{.python title=fields_enumerated.py}
+```{.python title="Enumerated Fields"}
 @strawberry.django.type(models.Fruit, fields=["name", "color"])
 class FruitType:
     pass
 ```
 
-```{.python title=fields_overriden.py}
+```{.python title="Overriden Fields"}
 @strawberry.django.type(models.Fruit, fields=["color"])
 class FruitType:
     name: str
@@ -147,13 +151,13 @@ Valid values for `exclude` are:
 
 - `[<List of field names>]` to exclude from the fields list. All other Django model fields will included and have `strawberry.auto` as the field type. These can also be overriden if another field type should be assigned. An empty list is ignored.
 
-```{.python title=exclude.py}
+```{.python title="Exclude Fields"}
 @strawberry.django.type(models.Fruit, exclude=["name"])
 class FruitType:
     pass
 ```
 
-```{.python title=exclude_overriden.py}
+```{.python title="Overriden Exclude Fields"}
 @strawberry.django.type(models.Fruit, exclude=["name"])
 class FruitType:
     color: int

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -123,7 +123,7 @@ strawberry_django.field_type_map.update({
 Valid values for `fields` are:
 
   * `__all__` to assign `strawberry.auto` as the field type for all model fields.
-  * [<List of field names>] to assign `strawberry.auto` as the field type for the enumerated fields. These can also be overriden if another field type should be assigned.
+  * `[<List of field names>]` to assign `strawberry.auto` as the field type for the enumerated fields. These can be combined with manual type annotations if needed.
 
 ```{.python title=fields_all.py}
 @strawberry.django.type(models.Fruit, fields="__all__")
@@ -138,14 +138,14 @@ class FruitType:
 ```
 
 ```{.python title=fields_overriden.py}
-@strawberry.django.type(models.Fruit, fields=["name", "color"])
+@strawberry.django.type(models.Fruit, fields=["color"])
 class FruitType:
     name: str
 ```
 
 Valid values for `exclude` are:
 
-  * [<List of field names>] to exclude from the fields list. All other Django model fields will included and have `strawberry.auto` as the field type. These can also be overriden if another field type should be assigned.
+  * `[<List of field names>]` to exclude from the fields list. All other Django model fields will included and have `strawberry.auto` as the field type. These can also be overriden if another field type should be assigned.
 
 ```{.python title=exclude.py}
 @strawberry.django.type(models.Fruit, exclude=["name"])

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -116,6 +116,49 @@ strawberry_django.field_type_map.update({
 })
 ```
 
+## Including / excluding Django model fields by name
+
+`strawberry.django.type` includes two optional keyword fields to help you more easily populate fields from the Django model, `fields` and `exclude`.
+
+Valid values for `fields` are:
+
+  * `__all__` to assign `strawberry.auto` as the field type for all model fields.
+  * [<List of field names>] to assign `strawberry.auto` as the field type for the enumerated fields. These can also be overriden if another field type should be assigned.
+
+```{.python title=fields_all.py}
+@strawberry.django.type(models.Fruit, fields="__all__")
+class FruitType:
+    pass
+```
+
+```{.python title=fields_enumerated.py}
+@strawberry.django.type(models.Fruit, fields=["name", "color"])
+class FruitType:
+    pass
+```
+
+```{.python title=fields_overriden.py}
+@strawberry.django.type(models.Fruit, fields=["name", "color"])
+class FruitType:
+    name: str
+```
+
+Valid values for `exclude` are:
+
+  * [<List of field names>] to exclude from the fields list. All other Django model fields will included and have `strawberry.auto` as the field type. These can also be overriden if another field type should be assigned.
+
+```{.python title=exclude.py}
+@strawberry.django.type(models.Fruit, exclude=["name"])
+class FruitType:
+    pass
+```
+
+```{.python title=exclude_overriden.py}
+@strawberry.django.type(models.Fruit, exclude=["name"])
+class FruitType:
+    color: int
+```
+
 ## Overriding the field class (advanced)
 
 If in your project, you want to change/add some of the standard `strawberry.django.field()` behaviour,

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -145,7 +145,7 @@ class FruitType:
 
 Valid values for `exclude` are:
 
-  * `[<List of field names>]` to exclude from the fields list. All other Django model fields will included and have `strawberry.auto` as the field type. These can also be overriden if another field type should be assigned.
+  * `[<List of field names>]` to exclude from the fields list. All other Django model fields will included and have `strawberry.auto` as the field type. These can also be overriden if another field type should be assigned. An empty list is ignored.
 
 ```{.python title=exclude.py}
 @strawberry.django.type(models.Fruit, exclude=["name"])

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -159,6 +159,8 @@ class FruitType:
     color: int
 ```
 
+Note that if `fields` has precedence over `exclude`, so if both are provided, then `exclude` is ignored.
+
 ## Overriding the field class (advanced)
 
 If in your project, you want to change/add some of the standard `strawberry.django.field()` behaviour,

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -96,7 +96,16 @@ def _process_type(
         model_fields = []
 
     existing_annotations = get_annotations(cls)
-    if not existing_annotations:
+    try:
+        cls.__annotations__
+    except AttributeError:
+        # Python 3.8 / 3.9 does not lazily create
+        #   cls.__annotations__ if it does not
+        #   exist, so we create it here.
+        # Note that Python 3.10+ will lazily create
+        #   cls.__annotations__, so this code
+        #   could be refactored / removed
+        #   once versions before 3.10 are not supported.
         cls.__annotations__ = {}
 
     for f in model_fields:

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -99,13 +99,11 @@ def _process_type(
     try:
         cls.__annotations__
     except AttributeError:
-        # Python 3.8 / 3.9 does not lazily create
-        #   cls.__annotations__ if it does not
-        #   exist, so we create it here.
-        # Note that Python 3.10+ will lazily create
-        #   cls.__annotations__, so this code
-        #   could be refactored / removed
-        #   once versions before 3.10 are not supported.
+        # Python 3.8 / 3.9 does not lazily create cls.__annotations__ if it
+        #   does not exist, so we create it here.
+        # Note that Python 3.10+ will lazily create cls.__annotations__,
+        #   so this code could be refactored / removed once versions before
+        #   3.10 are not supported.
         cls.__annotations__ = {}
 
     for f in model_fields:

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -97,7 +97,7 @@ def _process_type(
 
     existing_annotations = get_annotations(cls)
     try:
-        cls.__annotations__
+        cls.__annotations__  # noqa: B018
     except AttributeError:
         # Python 3.8 / 3.9 does not lazily create cls.__annotations__ if it
         #   does not exist, so we create it here.

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -80,7 +80,7 @@ def _process_type(
     select_related: Optional[TypeOrSequence[str]] = None,
     prefetch_related: Optional[TypeOrSequence[PrefetchType]] = None,
     disable_optimization: bool = False,
-    fields: Union[Optional[List[str]], str] = None,
+    fields: Optional[Union[List[str], str]] = None,
     exclude: Optional[List[str]] = None,
     **kwargs,
 ) -> _O:
@@ -415,7 +415,7 @@ def type(  # noqa: A001
     select_related: Optional[TypeOrSequence[str]] = None,
     prefetch_related: Optional[TypeOrSequence[PrefetchType]] = None,
     disable_optimization: bool = False,
-    fields: Union[Optional[List[str]], str] = None,
+    fields: Optional[Union[List[str], str]] = None,
     exclude: Optional[List[str]] = None,
 ) -> Callable[[_T], _T]:
     """Annotates a class as a Django GraphQL type.

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -5,6 +5,7 @@ import sys
 import types
 from typing import (
     Callable,
+    Collection,
     Generic,
     List,
     Optional,
@@ -13,7 +14,6 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    Collection,
 )
 
 import strawberry
@@ -97,7 +97,7 @@ def _process_type(
 
     existing_annotations = get_annotations(cls)
     if not existing_annotations:
-        cls.__annotations__ = dict()
+        cls.__annotations__ = {}
 
     for f in model_fields:
         if existing_annotations.get(f.name):

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -88,8 +88,6 @@ def _process_type(
 
     if not exclude:
         exclude = []
-    if not fields and is_input:
-        exclude += [model._meta.pk.name]
 
     if fields == "__all__":
         model_fields = list(model._meta.fields)

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -96,7 +96,7 @@ def _process_type(
     elif isinstance(exclude, collections.abc.Sequence) and len(exclude) > 0:
         model_fields = [f for f in model._meta.fields if f.name not in exclude]
     else:
-        model_fields = list()
+        model_fields = []
 
     for f in model_fields:
         if cls.__annotations__.get(f.name):

--- a/tests/models.py
+++ b/tests/models.py
@@ -22,7 +22,7 @@ class Fruit(models.Model):
     types = models.ManyToManyField("FruitType", related_name="fruits")
     sweetness = models.IntegerField(
         default=5,
-        help_text="Level of sweetness, from 1 to 10"
+        help_text="Level of sweetness, from 1 to 10",
     )
 
     def name_upper(self):

--- a/tests/models.py
+++ b/tests/models.py
@@ -20,6 +20,7 @@ class Fruit(models.Model):
         on_delete=models.CASCADE,
     )
     types = models.ManyToManyField("FruitType", related_name="fruits")
+    sweetness = models.IntegerField(help_text="Level of sweetness, from 1 to 10")
 
     def name_upper(self):
         return self.name.upper()

--- a/tests/models.py
+++ b/tests/models.py
@@ -20,7 +20,10 @@ class Fruit(models.Model):
         on_delete=models.CASCADE,
     )
     types = models.ManyToManyField("FruitType", related_name="fruits")
-    sweetness = models.IntegerField(help_text="Level of sweetness, from 1 to 10")
+    sweetness = models.IntegerField(
+        default=5,
+        help_text="Level of sweetness, from 1 to 10"
+    )
 
     def name_upper(self):
         return self.name.upper()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -270,8 +270,8 @@ def test_non_existent_fields_ignored():
     name_field = type_def.get_field("name")
     assert name_field is not None
     
-    sweetness_field = type_def.get_field("sweetness")
-    assert sweetness_field is None
+    sourness_field = type_def.get_field("sourness")
+    assert sourness_field is None
 
 
 def test_resolvers_with_fields():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,7 @@
+import textwrap
+
 import pytest
 import strawberry
-import textwrap
 from django.test import override_settings
 from strawberry import auto
 from strawberry.object_type import StrawberryObjectDefinition
@@ -242,7 +243,7 @@ def test_all_fields_works():
     """
 
     assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()
-    
+
 
 def test_can_override_type_when_fields_all():
     @strawberry_django.type(Fruit, fields="__all__")
@@ -338,7 +339,7 @@ def test_resolvers_with_fields():
         id: ID!
         name: String!
       }
-      
+
       type FruitType {
         name: String!
         color: ColorType!

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -229,7 +229,7 @@ def test_all_fields_works():
     assert sweetness_field is not None
     assert sweetness_field.type == int
     assert sweetness_field.description == Fruit._meta.get_field("sweetness").help_text
-    
+
 
 def test_can_override_type_when_fields_all():
     @strawberry_django.type(Fruit, fields="__all__")
@@ -252,7 +252,7 @@ def test_fields_can_be_enumerated():
 
     name_field = type_def.get_field("name")
     assert name_field is not None
-    
+
     sweetness_field = type_def.get_field("sweetness")
     assert sweetness_field is not None
 
@@ -269,7 +269,7 @@ def test_non_existent_fields_ignored():
 
     name_field = type_def.get_field("name")
     assert name_field is not None
-    
+
     sourness_field = type_def.get_field("sourness")
     assert sourness_field is None
 
@@ -280,7 +280,7 @@ def test_resolvers_with_fields():
         @strawberry.field
         def color(self, info, root) -> "ColorType":
             return root.color
-        
+
     @strawberry.type
     class Query:
         fruit: FruitType = strawberry_django.field()
@@ -305,7 +305,7 @@ def test_exclude_with_fields_is_ignored():
 
     name_field = type_def.get_field("name")
     assert name_field is not None
-    
+
     sweetness_field = type_def.get_field("sweetness")
     assert sweetness_field is not None
 
@@ -322,7 +322,7 @@ def test_exclude_includes_non_enumerated_fields():
 
     name_field = type_def.get_field("name")
     assert name_field is None
-    
+
     sweetness_field = type_def.get_field("sweetness")
     assert sweetness_field is not None
 
@@ -339,7 +339,7 @@ def test_non_existent_fields_exclude_ignored():
 
     name_field = type_def.get_field("name")
     assert name_field is not None
-    
+
     sweetness_field = type_def.get_field("sweetness")
     assert sweetness_field is not None
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Per [the discussion around issue 106](https://github.com/strawberry-graphql/strawberry-graphql-django/issues/106), this PR adds two keyword arguments to the `type` decorator -- `fields` and `exclude`. When provided, these arguments help auto-populate the Strawberry fields from the Django model, giving `strawberry.django` similar behavior to the `strawberry.pydantic` and `graphene-django` libraries.

Note that the core of the work was pulled from [the prior repository for `strawberry-django-plus`](https://github.com/blb-ventures/strawberry-django-plus/issues/85), and real credit goes to @mhdismail.

When included, `fields` can be:

* `__all__`. Automatically include all Django model fields, using `strawberry.auto` as the type annotation.
* `[<List of field names>]`. Include the listed Django model fields, using `strawberry.auto` as the type annotation. Invalid names are ignored.

When included, `exclude` can be:

* `[<List of field names>]`. Include all Django model fields **except** for the ones listed here, using `strawberry.auto` as the type annotation. Invalid names are ignored. Must include at least one item for this to take effect, an empty list is ignored.

`fields` has precedence over `exclude`, so if both are provided, `exclude` is ignored.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* #106 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [] I have tested the changes and verified that they work and don't break anything (as well as I can manage).


I added tests to cover the new code, but I don't have a local project using Strawberry that I can manually test / verify against ... so it might be helpful if someone could try this against a project they have locally?

@bellini666 , I had some time to migrate this over today.