### PR TITLE
fix: pass **kwargs to the type's `get_queryset` when defined

### DIFF
--- a/docs/guide/types.md
+++ b/docs/guide/types.md
@@ -92,7 +92,7 @@ like filtering it further.
 class Berry:
 
     @classmethod
-    def get_queryset(cls, queryset, info):
+    def get_queryset(cls, queryset, info, **kwargs):
         return queryset.filter(name__contains="berry")
 ```
 

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -252,7 +252,7 @@ class StrawberryDjangoField(
 
         get_queryset = getattr(type_, "get_queryset", None)
         if get_queryset:
-            queryset = get_queryset(queryset, info)
+            queryset = get_queryset(queryset, info, **kwargs)
 
         queryset = filter_with_perms(
             super().get_queryset(queryset, info, **kwargs),

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -67,6 +67,7 @@ class StaffType(relay.Node):
         cls,
         queryset: QuerySet[AbstractUser],
         info: Info,
+        **kwargs,
     ) -> QuerySet[AbstractUser]:
         return queryset.filter(is_staff=True)
 
@@ -146,7 +147,7 @@ class FavoriteType(relay.Node):
     issue: "IssueType"
 
     @classmethod
-    def get_queryset(cls, queryset: FavoriteQuerySet, info: Info) -> QuerySet:
+    def get_queryset(cls, queryset: FavoriteQuerySet, info: Info, **kwargs) -> QuerySet:
         return queryset.by_user(info.context.request.user)
 
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -39,7 +39,7 @@ class BerryFruit:
     name_lower: str
 
     @classmethod
-    def get_queryset(cls, queryset, info):
+    def get_queryset(cls, queryset, info, **kwargs):
         return queryset.filter(name__contains="berry")
 
 
@@ -52,7 +52,7 @@ class FruitInterface:
 @strawberry_django.type(models.Fruit)
 class BananaFruit(FruitInterface):
     @classmethod
-    def get_queryset(cls, queryset, info):
+    def get_queryset(cls, queryset, info, **kwargs):
         return queryset.filter(name__contains="banana")
 
 


### PR DESCRIPTION
Fix #294
