### PR TITLE
Fix missing model docstring crash

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -426,7 +426,7 @@ def resolve_model_field_type(
             doc = (
                 inspect.cleandoc(field_type.__doc__)
                 if settings["TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING"]
-                and field_type.__dict__
+                and field_type.__doc__
                 else None
             )
             enum_def = strawberry.enum(field_type, description=doc)._enum_definition


### PR DESCRIPTION
If TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING is set to True this will lead to crashes in many instances when there's no Python docstring provided.

This looks like a typo.
