### PR TITLE
refactor!: use a setting to decide if we should map fields to relay types or not

### DIFF
--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -30,7 +30,7 @@ input FruitFilter {
 
     If you are using the [relay integration](relay.md) and working with types inheriting
     from `relay.Node` and `GlobalID` for identifying objects, you might want to set
-    `MAP_AUTO_ID_AS_GLOBAL_ID=Trye` in your [strawberry django settings](../settings)
+    `MAP_AUTO_ID_AS_GLOBAL_ID=True` in your [strawberry django settings](../settings)
     to make sure `auto` fields gets mapped to `GlobalID` on types and filters.
 
 ## Lookups

--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -26,6 +26,13 @@ input FruitFilter {
 }
 ```
 
+!!! tip
+
+    If you are using the [relay integration](relay.md) and working with types inheriting
+    from `relay.Node` and `GlobalID` for identifying objects, you might want to set
+    `MAP_AUTO_ID_AS_GLOBAL_ID=Trye` in your [strawberry django settings](../settings)
+    to make sure `auto` fields gets mapped to `GlobalID` on types and filters.
+
 ## Lookups
 
 Lookups can be added to all fields with `lookups=True`, which will

--- a/docs/guide/relay.md
+++ b/docs/guide/relay.md
@@ -45,6 +45,13 @@ Behind the scenes this extension is doing the following for you:
 You can also define your own `relay.NodeID` field and your resolve, in the same way as
 `some_model_conn_with_resolver` is doing. In those cases, they will not be overridden.
 
+!!! tip
+
+    If you are only working with types inheriting from `relay.Node` and `GlobalID`
+    for identifying objects, you might want to set `MAP_AUTO_ID_AS_GLOBAL_ID=Trye`
+    in your [strawberry django settings](../settings) to make sure `auto` fields gets
+    mapped to `GlobalID` on types and filters.
+
 Also, this lib exposes a `strawberry_django.relay.ListConnectionWithTotalCount`, which works
 the same way as `strawberry.relay.ListConnection` does, but also exposes a
 `totalCount` attribute in the connection.

--- a/docs/guide/relay.md
+++ b/docs/guide/relay.md
@@ -48,7 +48,7 @@ You can also define your own `relay.NodeID` field and your resolve, in the same 
 !!! tip
 
     If you are only working with types inheriting from `relay.Node` and `GlobalID`
-    for identifying objects, you might want to set `MAP_AUTO_ID_AS_GLOBAL_ID=Trye`
+    for identifying objects, you might want to set `MAP_AUTO_ID_AS_GLOBAL_ID=True`
     in your [strawberry django settings](../settings) to make sure `auto` fields gets
     mapped to `GlobalID` on types and filters.
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -41,7 +41,13 @@ A dictionary with the following optional keys:
       an enum of possibilities instead of being exposed as `String`.
       A better option is to use
       [Django's TextChoices/IntegerChoices](https://docs.djangoproject.com/en/4.2/ref/models/fields/#enumeration-types)
-      with the [django-choices-field](../../integrations/choices-field.md) integration.
+      with the [django-choices-field](../integrations/choices-field.md) integration.
+
+- **`MAP_AUTO_ID_AS_GLOBAL_ID`** (default: `False`)
+
+      If True, `auto` fields that refer to model ids will be mapped to `relay.GlobalID`
+      instead of `strawberry.ID`. This is mostly useful if all your model types inherit
+      from `relay.Node` and you want to work only with `GlobalID`.
 
 These features can be enabled by adding this code to your `settings.py` file.
 
@@ -52,5 +58,6 @@ STRAWBERRY_DJANGO = {
     "MUTATIONS_DEFAULT_ARGUMENT_NAME": "input",
     "MUTATIONS_DEFAULT_HANDLE_ERRORS": True,
     "GENERATE_ENUMS_FROM_CHOICES": False,
+    "MAP_AUTO_ID_AS_GLOBAL_ID": True,
 }
 ```

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -465,22 +465,24 @@ def resolve_model_field_type(
             model_field._strawberry_enum = field_type  # type: ignore
     # Every other Field possibility
     else:
-        is_relay = issubclass(django_type.origin, relay.Node)
+        force_global_id = settings["MAP_AUTO_ID_AS_GLOBAL_ID"]
         model_field_type = type(model_field)
         field_type: Any = None
 
         if django_type.is_filter and model_field.is_relation:
-            field_type = NodeInput if is_relay else filters.DjangoModelFilterInput
+            field_type = (
+                NodeInput if force_global_id else filters.DjangoModelFilterInput
+            )
         elif django_type.is_input:
             input_type_map = input_field_type_map
-            if is_relay:
+            if force_global_id:
                 input_type_map = {**input_type_map, **relay_input_field_type_map}
 
             field_type = input_type_map.get(model_field_type, None)
 
         if field_type is None:
             type_map = field_type_map
-            if is_relay:
+            if force_global_id:
                 type_map = {**type_map, **relay_field_type_map}
 
             field_type = type_map.get(model_field_type, NotImplemented)

--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -25,13 +25,16 @@ class StrawberryDjangoSettings(TypedDict):
     #: an enum of possibilities instead of being exposed as `String`
     GENERATE_ENUMS_FROM_CHOICES: bool
 
-    #: If True, fields with `choices` will have automatically generate
-    #: an enum of possibilities instead of being exposed as `String`
+    #: Set a custom default name for CUD mutations input type.
     MUTATIONS_DEFAULT_ARGUMENT_NAME: str
 
-    #: If True, fields with `choices` will have automatically generate
-    #: an enum of possibilities instead of being exposed as `String`
+    #: If True, mutations will default to handling django errors by default
+    #: when no option is passed to the field itself.
     MUTATIONS_DEFAULT_HANDLE_ERRORS: bool
+
+    #: If True, `auto` fields that refer to model ids will be mapped to
+    #: `relay.GlobalID` instead of `strawberry.ID` for types and filters.
+    MAP_AUTO_ID_AS_GLOBAL_ID: bool
 
 
 DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
@@ -40,6 +43,7 @@ DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
     GENERATE_ENUMS_FROM_CHOICES=False,
     MUTATIONS_DEFAULT_ARGUMENT_NAME="data",
     MUTATIONS_DEFAULT_HANDLE_ERRORS=False,
+    MAP_AUTO_ID_AS_GLOBAL_ID=False,
 )
 
 

--- a/tests/fields/test_attributes.py
+++ b/tests/fields/test_attributes.py
@@ -1,12 +1,24 @@
+import textwrap
 from typing import cast
 
 import strawberry
 from django.db import models
-from strawberry import BasePermission, auto
+from django.test import override_settings
+from strawberry import BasePermission, auto, relay
 from strawberry.type import get_object_definition
 
 import strawberry_django
 from strawberry_django.fields.field import StrawberryDjangoField
+from strawberry_django.settings import strawberry_django_settings
+
+_global_id_desc = (
+    "The `ID` scalar type represents a unique identifier, "
+    "often used to refetch an object or as key for a cache. "
+    "The ID type appears in a JSON response as a String; "
+    "however, it is not intended to be human-readable. "
+    'When expected as an input type, any string (such as `"4"`) '
+    "or integer (such as `4`) input value will be accepted as an ID."
+)
 
 
 class FieldAttributeModel(models.Model):
@@ -51,3 +63,139 @@ def test_field_permission_classes():
             ("custom_resolved_field", [TestPermission]),
         ],
     )
+
+
+def test_auto_id():
+    @strawberry_django.filter(FieldAttributeModel)
+    class MyTypeFilter:
+        id: auto
+        field: auto
+
+    @strawberry_django.type(FieldAttributeModel)
+    class MyType:
+        id: auto
+        other_id: auto = strawberry_django.field(field_name="id")
+        field: auto
+
+    @strawberry.type
+    class Query:
+        my_type: list[MyType] = strawberry_django.field(filters=MyTypeFilter)
+
+    schema = strawberry.Schema(query=Query)
+    expected = """\
+    type MyType {
+      id: ID!
+      otherId: ID!
+      field: String!
+    }
+
+    input MyTypeFilter {
+      id: ID
+      field: String
+    }
+
+    type Query {
+      myType(filters: MyTypeFilter): [MyType!]!
+    }
+    """
+    assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()
+
+
+def test_auto_id_with_node():
+    @strawberry_django.filter(FieldAttributeModel)
+    class MyTypeFilter:
+        id: auto
+        field: auto
+
+    @strawberry_django.type(FieldAttributeModel)
+    class MyType(relay.Node):
+        other_id: auto = strawberry_django.field(field_name="id")
+        field: auto
+
+    @strawberry.type
+    class Query:
+        my_type: list[MyType] = strawberry_django.field(filters=MyTypeFilter)
+
+    schema = strawberry.Schema(query=Query)
+    expected = f'''\
+    """
+    {_global_id_desc}
+    """
+    scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+    type MyType implements Node {{
+      """The Globally Unique ID of this object"""
+      id: GlobalID!
+      otherId: ID!
+      field: String!
+    }}
+
+    input MyTypeFilter {{
+      id: ID
+      field: String
+    }}
+
+    """An object with a Globally Unique ID"""
+    interface Node {{
+      """The Globally Unique ID of this object"""
+      id: GlobalID!
+    }}
+
+    type Query {{
+      myType(filters: MyTypeFilter): [MyType!]!
+    }}
+    '''
+    assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()
+
+
+@override_settings(
+    STRAWBERRY_DJANGO={
+        **strawberry_django_settings(),
+        "MAP_AUTO_ID_AS_GLOBAL_ID": True,
+    },
+)
+def test_auto_id_with_node_mapping_global_id():
+    @strawberry_django.filter(FieldAttributeModel)
+    class MyTypeFilter:
+        id: auto
+        field: auto
+
+    @strawberry_django.type(FieldAttributeModel)
+    class MyType(relay.Node):
+        other_id: auto = strawberry_django.field(field_name="id")
+        field: auto
+
+    @strawberry.type
+    class Query:
+        my_type: list[MyType] = strawberry_django.field(filters=MyTypeFilter)
+
+    schema = strawberry.Schema(query=Query)
+    expected = f'''\
+    """
+    {_global_id_desc}
+    """
+    scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+    type MyType implements Node {{
+      """The Globally Unique ID of this object"""
+      id: GlobalID!
+      otherId: GlobalID!
+      field: String!
+    }}
+
+    input MyTypeFilter {{
+      id: GlobalID
+      field: String
+    }}
+
+    """An object with a Globally Unique ID"""
+    interface Node {{
+      """The Globally Unique ID of this object"""
+      id: GlobalID!
+    }}
+
+    type Query {{
+      myType(filters: MyTypeFilter): [MyType!]!
+    }}
+    '''
+    assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()

--- a/tests/fields/test_attributes.py
+++ b/tests/fields/test_attributes.py
@@ -1,5 +1,5 @@
 import textwrap
-from typing import cast
+from typing import List, cast
 
 import strawberry
 from django.db import models
@@ -79,7 +79,7 @@ def test_auto_id():
 
     @strawberry.type
     class Query:
-        my_type: list[MyType] = strawberry_django.field(filters=MyTypeFilter)
+        my_type: List[MyType] = strawberry_django.field(filters=MyTypeFilter)
 
     schema = strawberry.Schema(query=Query)
     expected = """\
@@ -114,7 +114,7 @@ def test_auto_id_with_node():
 
     @strawberry.type
     class Query:
-        my_type: list[MyType] = strawberry_django.field(filters=MyTypeFilter)
+        my_type: List[MyType] = strawberry_django.field(filters=MyTypeFilter)
 
     schema = strawberry.Schema(query=Query)
     expected = f'''\
@@ -167,7 +167,7 @@ def test_auto_id_with_node_mapping_global_id():
 
     @strawberry.type
     class Query:
-        my_type: list[MyType] = strawberry_django.field(filters=MyTypeFilter)
+        my_type: List[MyType] = strawberry_django.field(filters=MyTypeFilter)
 
     schema = strawberry.Schema(query=Query)
     expected = f'''\

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -26,6 +26,7 @@ def test_non_defaults():
             GENERATE_ENUMS_FROM_CHOICES=True,
             MUTATIONS_DEFAULT_ARGUMENT_NAME="id",
             MUTATIONS_DEFAULT_HANDLE_ERRORS=True,
+            MAP_AUTO_ID_AS_GLOBAL_ID=True,
         ),
     ):
         assert (
@@ -36,5 +37,6 @@ def test_non_defaults():
                 GENERATE_ENUMS_FROM_CHOICES=True,
                 MUTATIONS_DEFAULT_ARGUMENT_NAME="id",
                 MUTATIONS_DEFAULT_HANDLE_ERRORS=True,
+                MAP_AUTO_ID_AS_GLOBAL_ID=True,
             )
         )


### PR DESCRIPTION
`strawberry-django-plus` used to do that, but when migrating this
I thought it would be enough to check if the type itself inherits from
`relay.Node`.

It turns out that it is not, specially for filters as those doesn't
inherit from `relay.Node`.

This adds an option to allow the user to use `ID` or `GlobalID`
for their auto fields, meaning that someone that only uses `Node`
types can set `MAP_AUTO_ID_AS_GLOBAL_ID=True` to make sure that
it will only use `GlobalID` to map those.
