### PR TITLE
Fix TypeError with IntegerChoices and Add Tests for Enum Conversion without django_choices_field

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -436,7 +436,10 @@ def resolve_model_field_type(
         settings["GENERATE_ENUMS_FROM_CHOICES"]
         and isinstance(model_field, Field)
         and getattr(model_field, "choices", None)
-        and not isinstance(model_field.choices[0][0], int)
+        and not isinstance(
+            getattr(model_field, "choices", [])[0][0],
+            int,
+        )  # Exclude IntegerChoices
     ):
         choices = cast(List[Tuple[Any, str]], model_field.choices)
         field_type = getattr(model_field, "_strawberry_enum", None)

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -435,11 +435,8 @@ def resolve_model_field_type(
     elif (
         settings["GENERATE_ENUMS_FROM_CHOICES"]
         and isinstance(model_field, Field)
-        and getattr(model_field, "choices", None)
-        and not isinstance(
-            getattr(model_field, "choices", None)[0][0],
-            int,
-        )  # Exclude IntegerChoices
+        and (choices := getattr(model_field, "choices", None))
+        and not isinstance(choices[0][0], int)  # Exclude IntegerChoices
     ):
         choices = cast(List[Tuple[Any, str]], model_field.choices)
         field_type = getattr(model_field, "_strawberry_enum", None)

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -436,6 +436,10 @@ def resolve_model_field_type(
         settings["GENERATE_ENUMS_FROM_CHOICES"]
         and isinstance(model_field, Field)
         and getattr(model_field, "choices", None)
+        and not isinstance(
+            getattr(model_field, "choices", None)[0][0],
+            int,
+        )  # Exclude  IntegerChoices
     ):
         choices = cast(List[Tuple[Any, str]], model_field.choices)
         field_type = getattr(model_field, "_strawberry_enum", None)

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -435,8 +435,8 @@ def resolve_model_field_type(
     elif (
         settings["GENERATE_ENUMS_FROM_CHOICES"]
         and isinstance(model_field, Field)
-        and (choices := getattr(model_field, "choices", None))
-        and not isinstance(choices[0][0], int)  # Exclude IntegerChoices
+        and getattr(model_field, "choices", None)
+        and not isinstance(model_field.choices[0][0], int)
     ):
         choices = cast(List[Tuple[Any, str]], model_field.choices)
         field_type = getattr(model_field, "_strawberry_enum", None)

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -439,7 +439,7 @@ def resolve_model_field_type(
         and not isinstance(
             getattr(model_field, "choices", None)[0][0],
             int,
-        )  # Exclude  IntegerChoices
+        )  # Exclude IntegerChoices
     ):
         choices = cast(List[Tuple[Any, str]], model_field.choices)
         field_type = getattr(model_field, "_strawberry_enum", None)

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -154,6 +154,9 @@ def test_choices_field():
 
 
 def test_no_choices_enum(mocker: MockerFixture):
+    # We can't use patch with the module name directly as it tries to resolve
+    # strawberry.fields as a function instead of the module for python versions
+    # before 3.11
     mocker.patch.object(types, "TextChoicesField", None)
     mocker.patch.dict(field_type_map, {TextChoicesField: str})
     mocker.patch.object(types, "IntegerChoicesField", None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Resolved a bug that occurred when using IntegerChoices instead of django_choices_field.

  - The error message was as follows: TypeError: ChoicesType fields cannot be resolved. Cannot unpack non-iterable int object.
- Added unit tests for the conversion of TextChoices and IntegerChoices to Enums without using django_choices_field.

  - These tests aim to confirm consistency in behavior:
    - When handling TextChoices and IntegerChoices without using django_choices_field.
    - When handling choices that are simply specified as tuples.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
