### PR TITLE
Fix typo in optimizer docs for `strawberry.django.type` annotation

### DIFF
--- a/docs/guide/optimizer.md
+++ b/docs/guide/optimizer.md
@@ -220,7 +220,7 @@ class OrderItem:
     price: strawberry.auto
     quantity: strawberry.auto
 
-    @strawberry.django(only=["price", "quantity"])
+    @strawberry.django.field(only=["price", "quantity"])
     def total(self, root: models.OrderItem) -> decimal.Decimal:
         return root.price * root.quantity  # or root.total directly
 ```


### PR DESCRIPTION
## Description

The correct annotation should be `@strawberry.django.type` and not `@strawberry.django`. Otherwise you will get a "module is not callable" error.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR
N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
