### PR TITLE
feat: Add ValidationError code to OperationMessage

### DIFF
--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -61,6 +61,9 @@ type OperationMessage {
   The field that caused the error, or `null` if it isn't associated with any particular field.
   """
   field: String
+
+  """The error code, or `null` if no error code was set."""
+  code: String
 }
 
 type Fruit {

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -180,6 +180,7 @@ class OperationMessage:
     )
     code: Optional[str] = strawberry.field(
         description="The error code, or `null` if no error code was set.",
+        default=None,
     )
 
     def __eq__(self, other: Self):

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -178,6 +178,9 @@ class OperationMessage:
         ),
         default=None,
     )
+    code: Optional[str] = strawberry.field(
+        description="The error code, or `null` if no error code was set.",
+    )
 
     def __eq__(self, other: Self):
         if not isinstance(other, OperationMessage):
@@ -187,10 +190,11 @@ class OperationMessage:
             self.kind == other.kind
             and self.message == other.message
             and self.field == other.field
+            and self.code == other.code
         )
 
     def __hash__(self):
-        return hash((self.__class__, self.kind, self.message, self.field))
+        return hash((self.__class__, self.kind, self.message, self.field, self.code))
 
 
 @strawberry.type

--- a/strawberry_django/mutations/fields.py
+++ b/strawberry_django/mutations/fields.py
@@ -52,12 +52,13 @@ def _get_validation_errors(error: Exception):
 
     if isinstance(error, ValidationError) and hasattr(error, "error_dict"):
         # convert field errors
-        for field, field_errors in error.message_dict.items():
+        for field, field_errors in error.error_dict.items():
             for e in field_errors:
                 yield OperationMessage(
                     kind=kind,
                     field=to_camel_case(field) if field != NON_FIELD_ERRORS else None,
-                    message=e,
+                    message=e.message % e.params if e.params else e.message,
+                    code=getattr(e, "code", None),
                 )
     elif isinstance(error, ValidationError) and hasattr(error, "error_list"):
         # convert non-field errors
@@ -65,6 +66,7 @@ def _get_validation_errors(error: Exception):
             yield OperationMessage(
                 kind=kind,
                 message=e.message % e.params if e.params else e.message,
+                code=getattr(error, "code", None),
             )
     else:
         msg = getattr(error, "msg", None)
@@ -74,6 +76,7 @@ def _get_validation_errors(error: Exception):
         yield OperationMessage(
             kind=kind,
             message=msg,
+            code=getattr(error, "code", None),
         )
 
 

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -402,15 +402,29 @@ class Mutation:
     ) -> ProjectType:
         """Create project documentation."""
         if cost > 500:
+            # Field error without error code:
             raise ValidationError({"cost": "Cost cannot be higher than 500"})
+        if cost < 0:
+            # Field error with error code:
+            raise ValidationError(
+                {
+                    "cost": ValidationError(
+                        "Cost cannot be lower than zero",
+                        code="min_cost",
+                    ),
+                },
+            )
+        project = Project(
+            name=name,
+            cost=cost,
+            due_date=due_date,
+        )
+        project.full_clean()
+        project.save()
 
         return cast(
             ProjectType,
-            Project.objects.create(
-                name=name,
-                cost=cost,
-                due_date=due_date,
-            ),
+            project,
         )
 
     @mutations.input_mutation(handle_django_errors=True)

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -380,6 +380,9 @@ type OperationMessage {
   The field that caused the error, or `null` if it isn't associated with any particular field.
   """
   field: String
+
+  """The error code, or `null` if no error code was set."""
+  code: String
 }
 
 enum OperationMessageKind {


### PR DESCRIPTION
## Description

Extends the `OperationMessage` by a `code` attribute that is set to the `ValidationError.code` if available.

I changed the test project to apply Djangos default validation in order to test that error codes used by Django internally are passed through as expected.  This had the side-effect of turning a `datetime` object into a `date` object in an otherwise unrelated test.

## Types of Changes

- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* #356 

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
