### PR TITLE
fix: Update related objects with unique_together

### DIFF
--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -502,7 +502,8 @@ def update_m2m(
 
                 existing.discard(obj)
             else:
-                manager.create(**data)
+                obj, _ = manager.get_or_create(**data)
+                existing.discard(obj)
 
         for remaining in existing:
             if use_remove:
@@ -520,7 +521,7 @@ def update_m2m(
                 # Do this later in a bulk
                 to_add.append(obj)
             elif data:
-                manager.create(**data)
+                manager.get_or_create(**data)
             else:
                 raise AssertionError
 


### PR DESCRIPTION
## Description

Resolves the issue described in #360: Support updating related objects with `unique_together` on the foreign key where the data identifies a single object in the database.

## Types of Changes

- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* #360 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
