### PR TITLE
Support inList and nInList lookup in filters on enum

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -132,6 +132,12 @@ def build_filter_kwargs(
 
         if isinstance(field_value, Enum):
             field_value = field_value.value
+        elif (
+            isinstance(field_value, list)
+            and len(field_value) > 0
+            and isinstance(field_value[0], Enum)
+        ):
+            field_value = [el.value for el in field_value]
 
         negated = False
         if field_name.startswith("n_"):


### PR DESCRIPTION
## Description

Enum used in filters are evaluated to their `.value` for doing Django queries.

Unfortunately if a FilterLookup is used and a list is used for a lookup, then this transformation is not done, resulting in non-working django filter.

## Types of Changes
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

The correction is to check is the value is a non-empty list for at least one Enum and then create a new list with the `.value` of each enum.
I have added some unit tests.

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (to my knowledge)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document. (the file resides in `docs` but yes)
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
