### PR TITLE
Exclude id from model fields to avoid overriding the id: type

### DIFF
--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -95,6 +95,16 @@ def _process_type(
     else:
         model_fields = []
 
+    # If MAP_AUTO_ID_AS_GLOBAL_ID is True, we can no longer set the id
+    # from fields or it will override the GlobalID and return the default 
+    # django id instead in the query-result. This adjustment however still 
+    # does not fix if the id was set to auto manually on the ModelType.
+    MAP_AUTO_ID_AS_GLOBAL_ID = django_settings().get('MAP_AUTO_ID_AS_GLOBAL_ID', False)
+    if MAP_AUTO_ID_AS_GLOBAL_ID:
+        for f in model_fields[:]:
+            if f.name in ['id']:
+                model_fields.remove(f)
+
     existing_annotations = get_annotations(cls)
     try:
         cls.__annotations__  # noqa: B018


### PR DESCRIPTION
## Description

Excluding the id from model_fields when MAP_AUTO_ID_AS_GLOBAL_ID is set to True to allow the previously set annotation to handle the id without overriding it.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

#372 

## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
