### PR TITLE
Support annotate parameter in field to allow ORM annotations

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -59,7 +59,12 @@ if TYPE_CHECKING:
     from strawberry.unset import UnsetType
     from typing_extensions import Literal
 
-    from strawberry_django.utils.typing import PrefetchType, TypeOrSequence
+    from strawberry_django.utils.typing import (
+        AnnotateType,
+        PrefetchType,
+        TypeOrMapping,
+        TypeOrSequence,
+    )
 
 
 _T = TypeVar("_T")
@@ -97,6 +102,7 @@ class StrawberryDjangoField(
         only: TypeOrSequence[str] | None = None,
         select_related: TypeOrSequence[str] | None = None,
         prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+        annotate: TypeOrMapping[AnnotateType] | None = None,
         disable_optimization: bool = False,
         **kwargs,
     ):
@@ -105,6 +111,7 @@ class StrawberryDjangoField(
             only=only,
             select_related=select_related,
             prefetch_related=prefetch_related,
+            annotate=annotate,
         )
         super().__init__(*args, **kwargs)
 
@@ -397,6 +404,7 @@ def field(
     only: TypeOrSequence[str] | None = None,
     select_related: TypeOrSequence[str] | None = None,
     prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+    annotate: TypeOrMapping[AnnotateType] | None = None,
     disable_optimization: bool = False,
 ) -> _T: ...
 
@@ -424,6 +432,7 @@ def field(
     only: TypeOrSequence[str] | None = None,
     select_related: TypeOrSequence[str] | None = None,
     prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+    annotate: TypeOrMapping[AnnotateType] | None = None,
     disable_optimization: bool = False,
 ) -> Any: ...
 
@@ -451,6 +460,7 @@ def field(
     only: TypeOrSequence[str] | None = None,
     select_related: TypeOrSequence[str] | None = None,
     prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+    annotate: TypeOrMapping[AnnotateType] | None = None,
     disable_optimization: bool = False,
 ) -> StrawberryDjangoField: ...
 
@@ -477,6 +487,7 @@ def field(
     only: TypeOrSequence[str] | None = None,
     select_related: TypeOrSequence[str] | None = None,
     prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+    annotate: TypeOrMapping[AnnotateType] | None = None,
     disable_optimization: bool = False,
     # This init parameter is used by pyright to determine whether this field
     # is added in the constructor or not. It is not used to change
@@ -518,6 +529,7 @@ def field(
         only=only,
         select_related=select_related,
         prefetch_related=prefetch_related,
+        annotate=annotate,
         disable_optimization=disable_optimization,
     )
 
@@ -544,6 +556,7 @@ def node(
     only: TypeOrSequence[str] | None = None,
     select_related: TypeOrSequence[str] | None = None,
     prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+    annotate: TypeOrMapping[AnnotateType] | None = None,
     disable_optimization: bool = False,
     # This init parameter is used by pyright to determine whether this field
     # is added in the constructor or not. It is not used to change
@@ -610,6 +623,7 @@ def connection(
     only: TypeOrSequence[str] | None = None,
     select_related: TypeOrSequence[str] | None = None,
     prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+    annotate: TypeOrMapping[AnnotateType] | None = None,
     disable_optimization: bool = False,
 ) -> Any: ...
 
@@ -636,6 +650,7 @@ def connection(
     only: TypeOrSequence[str] | None = None,
     select_related: TypeOrSequence[str] | None = None,
     prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+    annotate: TypeOrMapping[AnnotateType] | None = None,
     disable_optimization: bool = False,
 ) -> Any: ...
 
@@ -660,6 +675,7 @@ def connection(
     only: TypeOrSequence[str] | None = None,
     select_related: TypeOrSequence[str] | None = None,
     prefetch_related: TypeOrSequence[PrefetchType] | None = None,
+    annotate: TypeOrMapping[AnnotateType] | None = None,
     disable_optimization: bool = False,
     # This init parameter is used by pyright to determine whether this field
     # is added in the constructor or not. It is not used to change
@@ -745,6 +761,7 @@ def connection(
         only=only,
         select_related=select_related,
         prefetch_related=prefetch_related,
+        annotate=annotate,
         disable_optimization=disable_optimization,
     )
 

--- a/strawberry_django/utils/typing.py
+++ b/strawberry_django/utils/typing.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     ClassVar,
     Iterable,
+    Mapping,
     Sequence,
     TypeVar,
     Union,
@@ -15,6 +16,7 @@ from typing import (
 )
 
 from django.db.models import Prefetch
+from django.db.models.expressions import BaseExpression
 from graphql.type.definition import GraphQLResolveInfo
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.auto import StrawberryAuto
@@ -37,10 +39,13 @@ _T = TypeVar("_T")
 _Type = TypeVar("_Type", bound="StrawberryType | type")
 
 TypeOrSequence: TypeAlias = Union[_T, Sequence[_T]]
+TypeOrMapping: TypeAlias = Union[_T, Mapping[str, _T]]
 TypeOrIterable: TypeAlias = Union[_T, Iterable[_T]]
 UserType: TypeAlias = Union["AbstractBaseUser", "AnonymousUser"]
 PrefetchCallable: TypeAlias = Callable[[GraphQLResolveInfo], Prefetch]
 PrefetchType: TypeAlias = Union[str, Prefetch, PrefetchCallable]
+AnnotateCallable: TypeAlias = Callable[[GraphQLResolveInfo], BaseExpression]
+AnnotateType: TypeAlias = Union[BaseExpression, AnnotateCallable]
 
 
 class WithStrawberryDjangoObjectDefinition(WithStrawberryObjectDefinition, Protocol):

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -11,6 +11,8 @@ for cls in [QuerySet, BaseManager, models.ForeignKey, models.ManyToManyField]:
 
 DEBUG = True
 SECRET_KEY = 1
+USE_TZ = True
+TIME_ZONE = "UTC"
 
 DATABASES = {
     "default": {

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -7,7 +7,16 @@ import strawberry
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
-from django.db.models import Exists, OuterRef, Prefetch
+from django.db.models import (
+    BooleanField,
+    Count,
+    Exists,
+    ExpressionWrapper,
+    OuterRef,
+    Prefetch,
+    Q,
+)
+from django.db.models.functions import Now
 from django.db.models.query import QuerySet
 from strawberry import relay
 from strawberry.types.info import Info
@@ -83,6 +92,13 @@ class ProjectType(relay.Node):
     name: strawberry.auto
     due_date: strawberry.auto
     milestones: List["MilestoneType"]
+    milestones_count: int = strawberry_django.field(annotate=Count("milestone"))
+    is_delayed: bool = strawberry_django.field(
+        annotate=ExpressionWrapper(
+            Q(due_date__lt=Now()),
+            output_field=BooleanField(),
+        ),
+    )
     cost: strawberry.auto = strawberry_django.field(extensions=[IsAuthenticated()])
 
 
@@ -133,6 +149,20 @@ class MilestoneType(relay.Node):
     )
     def my_issues(self) -> List["IssueType"]:
         return self._my_issues  # type: ignore
+
+    @strawberry_django.field(
+        annotate={
+            "_my_bugs_count": lambda info: Count(
+                "issue",
+                filter=Q(
+                    issue__issue_assignee__user_id=info.context.request.user.id,
+                    issue__kind=Issue.Kind.BUG,
+                ),
+            ),
+        },
+    )
+    def my_bugs_count(self) -> int:
+        return self._my_bugs_count  # type: ignore
 
     @strawberry_django.field
     async def async_field(self, value: str) -> str:

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -303,6 +303,7 @@ type MilestoneType implements Node {
   project: ProjectType!
   issues: [IssueType!]!
   myIssues: [IssueType!]!
+  myBugsCount: Int!
   asyncField(value: String!): String!
 }
 
@@ -448,6 +449,8 @@ type ProjectType implements Node {
   name: String!
   dueDate: Date
   milestones(filters: MilestoneFilter, order: MilestoneOrder): [MilestoneType!]!
+  milestonesCount: Int!
+  isDelayed: Boolean!
   cost: Decimal @isAuthenticated
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds support for ORM annotations as fields. Looks like this:
```python
class ProjectType(relay.Node):
    milestones_count: int = strawberry_django.field(annotate=Count("milestone"))  # here!
```

And this:
```python
@strawberry_django.type(Milestone)
class MilestoneType(relay.Node):
    @strawberry_django.field(
        annotate={
            "_my_bugs_count": lambda info: Count(
                "issue",
                filter=Q(
                    issue__issue_assignee__user_id=info.context.request.user.id,
                    issue__kind=Issue.Kind.BUG,
                ),
            ),
        },
    )
    def my_bugs_count(self) -> int:
        return self._my_bugs_count  # type: ignore
```

There are some shortcomings and implementation details that I discuss more in-depth in PR comments. The main one is this only works if `DjangoOptimizerExtension` is enabled. Although that doesn't look like a major issue to me, because custom prefetches also have the same limitation (see the existing `tests/test_optimizer.py::test_query_prefetch_with_callable`).

**As of Sept 27 2023, this PR is still missing docs. I'll wait for feedback on implementation and field "syntax" before making the docs.** I already added some tests, but perhaps we need more. I still also have to test manually a bit more.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
