### PR TITLE
Fix: DjangoOptimizerExtension corrupts nested objects' fields' prefetch objects

### DIFF
--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import copy
 import dataclasses
 import itertools
 from collections import defaultdict
-from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -198,7 +198,7 @@ class OptimizerStore:
                 prefetch_related.append(f"{prefix}{LOOKUP_SEP}{p}")
             elif isinstance(p, Prefetch):
                 # add_prefix modifies the field's prefetch object, so we copy it before
-                p_copy = deepcopy(p)
+                p_copy = copy.copy(p)
                 p_copy.add_prefix(prefix)
                 prefetch_related.append(p_copy)
             else:  # pragma:nocover

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -5,6 +5,7 @@ import contextvars
 import dataclasses
 import itertools
 from collections import defaultdict
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -196,8 +197,10 @@ class OptimizerStore:
             if isinstance(p, str):
                 prefetch_related.append(f"{prefix}{LOOKUP_SEP}{p}")
             elif isinstance(p, Prefetch):
-                p.add_prefix(prefix)
-                prefetch_related.append(p)
+                # add_prefix modifies the field's prefetch object, so we copy it before
+                p_copy = deepcopy(p)
+                p_copy.add_prefix(prefix)
+                prefetch_related.append(p_copy)
             else:  # pragma:nocover
                 assert_never(p)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,6 +15,7 @@ from django.test.utils import CaptureQueriesContext
 from strawberry.test.client import Response
 from strawberry.utils.inspect import in_async_context
 
+from strawberry_django.optimizer import DjangoOptimizerExtension
 from strawberry_django.test.client import TestClient
 
 _client: contextvars.ContextVar["GraphQLTestClient"] = contextvars.ContextVar(
@@ -22,7 +23,7 @@ _client: contextvars.ContextVar["GraphQLTestClient"] = contextvars.ContextVar(
 )
 
 
-def generate_query(query=None, mutation=None):
+def generate_query(query=None, mutation=None, enable_optimizer=False):
     append_mutation = mutation and not query
     if query is None:
 
@@ -31,7 +32,11 @@ def generate_query(query=None, mutation=None):
             x: int
 
         query = Query
-    schema = strawberry.Schema(query=query, mutation=mutation)
+    extensions = []
+
+    if enable_optimizer:
+        extensions = [DjangoOptimizerExtension()]
+    schema = strawberry.Schema(query=query, mutation=mutation, extensions=extensions)
 
     def process_result(result):
         return result


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR aims to resolve issue #379 .

I included a reproducible test and a suggested fix, where the `Prefetch` object gets deepcopied to avoid the side effects from `add_prefix`. 

Considerations:
- There were multiple ways to do this, including copying the OptimizerStore at a higher level in the execution stack, but this should be the least invasive one 
- I used deepcopy now as Prefetch didn't offer an easier way of copying the object that I know of, I'm happy about suggestions on improving this

I'm also very open for improving the test case included. If you know a better way on how to do it without the custom type setup, please let me know.


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #379 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I love the work you do here, thanks a lot for the really awesome work! ❤️
