### PR TITLE
compatibility ASGI/websockets get_request, login and logout

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,11 +2,13 @@
 
 ## How to access Django request object in resolvers?
 
-The request object is accessible via the `info.context.request` object.
+The request object is accessible via the `get_request` method.
 
 ```python
+from strawberry_django.auth.utils import get_request
+
 def resolver(root, info: Info):
-    request = info.context.request
+    request = get_request(info)
 ```
 
 ## How to access the current user object in resolvers?

--- a/strawberry_django/auth/mutations.py
+++ b/strawberry_django/auth/mutations.py
@@ -40,7 +40,7 @@ def resolve_login(info: Info, username: str, password: str) -> AbstractBaseUser 
             # request is actually channelsrequest
             try:
                 scope = request.consumer.scope  # type: ignore
-                async_to_sync(channels_auth.login)(scope, user)
+                async_to_sync(channels_auth.login)(scope, user)  # type: ignore
                 # According to channels docs you must save the session
                 scope["session"].save()
             except (AttributeError, NameError):
@@ -63,7 +63,7 @@ def resolve_logout(info: Info) -> bool:
     except AttributeError:
         try:
             scope = request.consumer.scope  # type: ignore
-            async_to_sync(channels_auth.logout)(scope)
+            async_to_sync(channels_auth.logout)(scope)  # type: ignore
         except (AttributeError, NameError):
             # When Django-channels is not installed,
             # this code will be non-existing

--- a/strawberry_django/auth/mutations.py
+++ b/strawberry_django/auth/mutations.py
@@ -11,6 +11,7 @@ from strawberry_django.mutations import mutations, resolvers
 from strawberry_django.mutations.fields import DjangoCreateMutation
 from strawberry_django.optimizer import DjangoOptimizerExtension
 from strawberry_django.resolvers import django_resolver
+from strawberry_django.utils.requests import get_request
 
 if TYPE_CHECKING:
     from django.contrib.auth.base_user import AbstractBaseUser
@@ -19,18 +20,20 @@ if TYPE_CHECKING:
 
 @django_resolver
 def resolve_login(info: Info, username: str, password: str) -> AbstractBaseUser | None:
-    request = info.context.request
+    request = get_request(info)
     user = auth.authenticate(request, username=username, password=password)
+
     if user is not None:
         auth.login(request, user)
         return user
+
     auth.logout(request)
     return None
 
 
 @django_resolver
 def resolve_logout(info: Info) -> bool:
-    request = info.context.request
+    request = get_request(info)
     ret = request.user.is_authenticated
     auth.logout(request)
     return ret

--- a/strawberry_django/auth/mutations.py
+++ b/strawberry_django/auth/mutations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import functools
 from typing import TYPE_CHECKING, Any, Type, cast
 
@@ -16,10 +15,12 @@ from strawberry_django.optimizer import DjangoOptimizerExtension
 from strawberry_django.resolvers import django_resolver
 from strawberry_django.utils.requests import get_request
 
-with contextlib.suppress(ModuleNotFoundError):
+try:
     # Django-channels is not always used/intalled,
     # therefore it shouldn't be it a hard requirement.
     from channels import auth as channels_auth
+except ModuleNotFoundError:
+    channels_auth = None
 
 if TYPE_CHECKING:
     from django.contrib.auth.base_user import AbstractBaseUser

--- a/strawberry_django/auth/mutations.py
+++ b/strawberry_django/auth/mutations.py
@@ -39,8 +39,6 @@ def resolve_login(info: Info, username: str, password: str) -> AbstractBaseUser 
             scope["session"].save()
         return user
 
-    # FIXME: Why call logout inside login??
-    auth.logout(request)
     return None
 
 

--- a/strawberry_django/auth/mutations.py
+++ b/strawberry_django/auth/mutations.py
@@ -33,7 +33,7 @@ def resolve_login(info: Info, username: str, password: str) -> AbstractBaseUser 
             # ASGI in combo with websockets needs the channels login functionality.
             # to ensure we're talking about channels, let's veriy that our
             # request is actually channelsrequest
-            scope = request.consumer.scope
+            scope = request.consumer.scope  # type: ignore
             async_to_sync(channels_auth.login)(scope, user)
             # According to channels docs you must save the session
             scope["session"].save()
@@ -47,13 +47,13 @@ def resolve_login(info: Info, username: str, password: str) -> AbstractBaseUser 
 @django_resolver
 def resolve_logout(info: Info) -> bool:
     user = get_current_user(info)
-    ret = user.is_authenticated
+    ret = user.is_authenticated  # type: ignore
 
     try:
         request = get_request(info)
         auth.logout(request)
     except AttributeError:
-        scope = request.consumer.scope
+        scope = request.consumer.scope  # type: ignore
         async_to_sync(channels_auth.logout)(scope)
 
     return ret

--- a/strawberry_django/auth/utils.py
+++ b/strawberry_django/auth/utils.py
@@ -24,10 +24,10 @@ def get_current_user(info: Info, *, strict: bool = False) -> Optional[UserType]:
     except AttributeError:
         try:
             # queries/mutations in ASGI move the user into consumer scope
-            user = request.consumer.scope["user"]
+            user = request.consumer.scope["user"]  # type: ignore
         except AttributeError:
             # websockets / subscriptions move scope inside of the request
-            user = request.scope.get("user")
+            user = request.scope.get("user")  # type: ignore
 
     if user is None:
         raise ValueError("No user found in the current request")

--- a/strawberry_django/utils/requests.py
+++ b/strawberry_django/utils/requests.py
@@ -1,0 +1,17 @@
+from django.http.request import HttpRequest
+from strawberry.types import Info
+
+
+def get_request(info: Info) -> HttpRequest:
+    """Return the request from Info.
+
+    description:
+    Return the request object for both WSGI and ASGI implementations.
+    It tends to move based on the environment.
+    """
+    try:
+        request = info.context.request
+    except AttributeError:
+        request = info.context.get("request")
+
+    return request


### PR DESCRIPTION
The context object can turn into a dict when using ASGI.  This pull requests accounts for both ASGI and WSGI conditions and replaces the use of `info.context.request` with `get_request(info)`