### PR TITLE
docs: Fix typos in object-level Permissions documentation

### DIFF
--- a/docs/guide/permissions.md
+++ b/docs/guide/permissions.md
@@ -54,7 +54,7 @@ class SomeType:
     )
     obj_perm_required_field: OtherType = strawberry_django.field(
         # will check the permission for the resolved value
-        extensions=[HasObjPerm("some_app.some_perm")],
+        extensions=[HasRetvalPerm("some_app.some_perm")],
     )
 ```
 
@@ -77,9 +77,9 @@ Available options are:
 
 !!! note
 
-    The `HasObjPerm` extension requires having an
+    The `HasSourcePerm` and `HasRetvalPerm` require having an
     [authentication backend](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/)
-    which supports resolving object permissions. This lib is works out of the box with
+    which supports resolving object permissions. This lib works out of the box with
     [django-guardian](https://django-guardian.readthedocs.io/en/stable/), so if you are
     using it you don't need to do anything else.
 

--- a/strawberry_django/permissions.py
+++ b/strawberry_django/permissions.py
@@ -603,7 +603,7 @@ class HasPerm(DjangoPermissionExtension):
 
         >>> @strawberry.type
         ... class Query:
-        ...     @strawberry.mutation(directives=[PermRequired("product.add_product")])
+        ...     @strawberry.mutation(directives=[HasPerm("product.add_product")])
         ...     def create_product(self, name: str) -> ProductType:
         ...         ...
 
@@ -875,7 +875,7 @@ class HasSourcePerm(HasPerm):
 
     This will check the permissions for the source object to access the given field.
 
-    Unlike `ObjPermRequired`, this uses the source value (the object where the field
+    Unlike `HasRetvalPerm`, this uses the source value (the object where the field
     is defined) to resolve the field, which means that this cannot be used for source
     queries and types.
 
@@ -885,9 +885,9 @@ class HasSourcePerm(HasPerm):
         the user has "product.view_field" in it in the django system:
 
         >>> @gql.django.type(Product)
-        ... class ProdyctType:
+        ... class ProductType:
         ...     some_field: str = strawberry.field(
-        ...         directives=[SourcePermRequired(".add_product")],
+        ...         directives=[HasSourcePerm(".add_product")],
         ...     )
 
     """
@@ -906,7 +906,7 @@ class HasRetvalPerm(HasPerm):
     if he has any of the permissions defined in this directive.
 
     Note that this depends on resolving the object to check the permissions
-    specifically for that object, unlike `PermRequired` which checks it before resolving
+    specifically for that object, unlike `HasPerm` which checks it before resolving.
 
     Examples
     --------
@@ -917,7 +917,7 @@ class HasRetvalPerm(HasPerm):
         >>> @strawberry.type
         ... class SomeType:
         ...     product: ProductType = strawberry.field(
-        ...         directives=[ObjPermRequired(".add_product")],
+        ...         directives=[HasRetvalPerm(".add_product")],
         ...     )
 
     """


### PR DESCRIPTION
## Description

There seemed to be some stale references to class names that don't exist (e.g., `HasObjPerm`, `ObjPermRequired`), so this changes them to refer to the current permission directive class names.

I believe I made these updates correctly, but haven't actually used the library yet myself, so please let me know if anything needs tweaking.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR
n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
