### PR TITLE
fix: Use _RESOLVER_TYPE as the type for the resolver on field, so the…

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -384,7 +384,7 @@ class StrawberryDjangoConnectionExtension(relay.ConnectionExtension):
 def field(
     *,
     field_cls: type[StrawberryDjangoField] = StrawberryDjangoField,
-    resolver: Callable[[], _T],
+    resolver: _RESOLVER_TYPE[_T],
     name: str | None = None,
     field_name: str | None = None,
     is_subscription: bool = False,
@@ -439,7 +439,7 @@ def field(
 
 @overload
 def field(
-    resolver: StrawberryResolver | Callable | staticmethod | classmethod,
+    resolver: _RESOLVER_TYPE,
     *,
     field_cls: type[StrawberryDjangoField] = StrawberryDjangoField,
     name: str | None = None,


### PR DESCRIPTION
… correct type is returned when using a resolver with arguments.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Relate to this [issue](https://github.com/strawberry-graphql/strawberry-graphql-django/issues/411), use the type `_RESOLVER_TYPE` for field's resolver type, so it returns the correct type when using a resolver with arguments, and stop pyright from complaining about incorrect types.


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #411

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
