### PR TITLE
fix: make sure custom fields are kept during inheritance

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from strawberry.relay.types import NodeIterableType
     from strawberry.types.info import Info
     from strawberry.unset import UnsetType
-    from typing_extensions import Literal
+    from typing_extensions import Literal, Self
 
     from strawberry_django.utils.typing import (
         AnnotateType,
@@ -114,6 +114,12 @@ class StrawberryDjangoField(
             annotate=annotate,
         )
         super().__init__(*args, **kwargs)
+
+    def __copy__(self) -> Self:
+        new_field = super().__copy__()
+        new_field.disable_optimization = self.disable_optimization
+        new_field.store = self.store.copy()
+        return new_field
 
     @cached_property
     def _need_remove_filters_argument(self):

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -352,6 +352,8 @@ def _process_type(
             # seeing it, just update its annotations/description/etc
             f.type_annotation = type_annotation
             f.description = description
+        elif isinstance(f, StrawberryDjangoField):
+            f = copy.copy(f)  # noqa: PLW2901
         elif (
             not isinstance(f, StrawberryDjangoField)
             and getattr(f, "base_resolver", None) is not None


### PR DESCRIPTION
When a type is using a custom field, inheriting from it should not change that field back to a `StrawberryDjangoField`

Fix #414
