### PR TITLE
Guarantee 'AND', 'OR', and 'NOT' filter fields get evaluated last by …

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -180,6 +180,8 @@ def build_filter_kwargs(
         else None
     )
 
+    # This loop relies on the filter field order: AND, OR, and NOT fields are expected to be last. Since this is not
+    # true in case of filter inheritance, we need to explicitely sort them.
     for f in sorted(
         filters.__strawberry_definition__.fields, key=lambda f: f.name, reverse=True
     ):

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -180,7 +180,9 @@ def build_filter_kwargs(
         else None
     )
 
-    for f in filters.__strawberry_definition__.fields:
+    for f in sorted(
+        filters.__strawberry_definition__.fields, key=lambda f: f.name, reverse=True
+    ):
         field_name = f.name
         field_value = _resolve_global_id(getattr(filters, field_name))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,16 @@ def fruits(db):
 
 
 @pytest.fixture()
+def vegetables(db):
+    vegetable_names = ["carrot", "cucumber", "onion"]
+    vegetable_world_production = [40.0e6, 75.2e6, 102.2e6]  # in tons
+    return [
+        models.Vegetable.objects.create(name=n, world_production=p)
+        for n, p in zip(vegetable_names, vegetable_world_production)
+    ]
+
+
+@pytest.fixture()
 def tag(db):
     return models.Tag.objects.create(name="tag")
 

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -285,8 +285,26 @@ def test_resolver_filter_with_inheritance(vegetables):
 
     query = utils.generate_query(Query)
     result = query(
-        "{ vegetables(filters:  { worldProduction: { gt: 100e6 } "
-        'OR: { name: { exact: "cucumber" } } }) { id name } }'
+        """
+      {
+        vegetables(
+          filters: {
+            worldProduction: {
+              gt: 100e6
+            }
+            OR: {
+              name: {
+                exact: "cucumber"
+              }
+            }
+          }
+        )
+        {
+          id
+          name
+        }
+      }
+    """
     )
     assert isinstance(result, ExecutionResult)
     assert not result.errors

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -12,6 +12,18 @@ import strawberry_django
 from tests import models, utils
 
 
+@strawberry_django.filter(models.NameDescriptionMixin)
+class NameDescriptionFilter:
+    name: auto
+    description: auto
+
+
+@strawberry_django.filter(models.Vegetable, lookups=True)
+class VegetableFilter(NameDescriptionFilter):
+    id: auto
+    world_production: auto
+
+
 @strawberry_django.filters.filter(models.Color, lookups=True)
 class ColorFilter:
     id: auto
@@ -75,6 +87,14 @@ class TypeFilter:
             return queryset
 
         return queryset.filter(name__icontains=self.name)
+
+
+@strawberry_django.type(models.Vegetable, filters=VegetableFilter)
+class Vegetable:
+    id: auto
+    name: auto
+    description: auto
+    world_production: auto
 
 
 @strawberry_django.type(models.Fruit, filters=FruitFilter)
@@ -250,6 +270,30 @@ def test_resolver_filter(fruits):
     assert result.data is not None
     assert result.data["fruits"] == [
         {"id": "1", "name": "strawberry"},
+    ]
+
+
+def test_resolver_filter_with_inheritance(vegetables):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def vegetables(self, filters: VegetableFilter) -> List[Vegetable]:
+            queryset = models.Vegetable.objects.all()
+            return cast(
+                List[Vegetable], strawberry_django.filters.apply(filters, queryset)
+            )
+
+    query = utils.generate_query(Query)
+    result = query(
+        "{ vegetables(filters:  { worldProduction: { gt: 100e6 } "
+        'OR: { name: { exact: "cucumber" } } }) { id name } }'
+    )
+    assert isinstance(result, ExecutionResult)
+    assert not result.errors
+    assert result.data is not None
+    assert result.data["vegetables"] == [
+        {"id": "2", "name": "cucumber"},
+        {"id": "3", "name": "onion"},
     ]
 
 

--- a/tests/filters/test_types.py
+++ b/tests/filters/test_types.py
@@ -29,35 +29,6 @@ def test_filter():
     ]
 
 
-def test_filter_field_order_with_inheritance():
-    @strawberry_django.filter(models.NameDescriptionMixin)
-    class NameDescriptionFilter:
-        name: auto
-        description: auto
-
-    @strawberry_django.filter(models.Vegetable)
-    class VegetableFilter(NameDescriptionFilter):
-        id: auto
-        world_production: auto
-
-    # What is the expected order in case of filter inheritance?
-    # Base class fields first followed by subclass fields or alphabetical order?
-    # Maybe it is possible to use __init_subclass__ to order the filter fields in a deterministic way?
-    object_definition = get_object_definition(VegetableFilter, strict=True)
-    assert [
-        (f.name, f.type.of_type.__name__)  # type: ignore
-        for f in object_definition.fields
-    ] == [
-        ("id", "FilterLookup"),
-        ("name", "FilterLookup"),
-        ("description", "FilterLookup"),
-        ("world_production", "FilterLookup"),
-        ("AND", "Filter"),
-        ("OR", "Filter"),
-        ("NOT", "Filter"),
-    ]
-
-
 def test_lookups():
     @strawberry_django.filters.filter(models.Fruit, lookups=True)
     class Filter:

--- a/tests/filters/test_types.py
+++ b/tests/filters/test_types.py
@@ -29,6 +29,35 @@ def test_filter():
     ]
 
 
+def test_filter_field_order_with_inheritance():
+    @strawberry_django.filter(models.NameDescriptionMixin)
+    class NameDescriptionFilter:
+        name: auto
+        description: auto
+
+    @strawberry_django.filter(models.Vegetable)
+    class VegetableFilter(NameDescriptionFilter):
+        id: auto
+        world_production: auto
+
+    # What is the expected order in case of filter inheritance?
+    # Base class fields first followed by subclass fields or alphabetical order?
+    # Maybe it is possible to use __init_subclass__ to order the filter fields in a deterministic way?
+    object_definition = get_object_definition(VegetableFilter, strict=True)
+    assert [
+        (f.name, f.type.of_type.__name__)  # type: ignore
+        for f in object_definition.fields
+    ] == [
+        ("id", "FilterLookup"),
+        ("name", "FilterLookup"),
+        ("description", "FilterLookup"),
+        ("world_production", "FilterLookup"),
+        ("AND", "Filter"),
+        ("OR", "Filter"),
+        ("NOT", "Filter"),
+    ]
+
+
 def test_lookups():
     @strawberry_django.filters.filter(models.Fruit, lookups=True)
     class Filter:

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,6 +14,18 @@ def validate_fruit_type(value: str):
         raise ValidationError("We do not allow rotten fruits.")
 
 
+class NameDescriptionMixin(models.Model):
+    name = models.CharField(max_length=20)
+    description = models.TextField()
+
+    class Meta:
+        abstract = True
+
+
+class Vegetable(NameDescriptionMixin):
+    world_production = models.FloatField()
+
+
 class Fruit(models.Model):
     name = models.CharField(max_length=20)
     color_id: Optional[int]


### PR DESCRIPTION
…sorting 'filters.__strawberry_definition__.fields'; fixed issue #422;

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

#422

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
