### PR TITLE
fix: HasPerm on async fields, fix missing query in another test

### DIFF
--- a/strawberry_django/permissions.py
+++ b/strawberry_django/permissions.py
@@ -42,7 +42,7 @@ from strawberry.types.info import Info
 from strawberry.union import StrawberryUnion
 from typing_extensions import Literal, assert_never
 
-from strawberry_django.auth.utils import get_current_user
+from strawberry_django.auth.utils import aget_current_user, get_current_user
 from strawberry_django.fields.types import OperationInfo, OperationMessage
 from strawberry_django.resolvers import django_resolver
 
@@ -334,7 +334,7 @@ class DjangoPermissionExtension(FieldExtension, abc.ABC):
         info: Info,
         **kwargs: Dict[str, Any],
     ) -> Any:
-        user = get_current_user(info)
+        user = await aget_current_user(info)
 
         try:
             from .integrations.guardian import get_user_or_anonymous

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -385,6 +385,12 @@ class Query:
         extensions=[HasRetvalPerm(perms=["projects.view_issue"])],
     )
 
+    @strawberry_django.field(
+        extensions=[HasPerm(perms=["projects.view_issue"], with_superuser=True)]
+    )
+    async def async_user_resolve(self) -> bool:
+        return True
+
     @strawberry_django.field
     def me(self, info: Info) -> Optional[UserType]:
         user = get_current_user(info, strict=True)

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -682,6 +682,7 @@ type Query {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): IssueTypeConnection! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
+  asyncUserResolve: Boolean! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   me: UserType
   projectConnWithResolver(
     name: String!

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -189,6 +189,11 @@ def test_superuser_required(db, gql_client: GraphQLTestClient):
 
     user = UserFactory.create()
     with gql_client.login(user):
+        res = gql_client.query(
+            query,
+            {"id": to_base64("IssueType", issue.pk)},
+            asserts_errors=False,
+        )
         assert res.data is None
         assert res.errors == [
             {
@@ -207,6 +212,43 @@ def test_superuser_required(db, gql_client: GraphQLTestClient):
                 "name": issue.name,
             },
         }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_async_user_resolve(db, gql_client: GraphQLTestClient):
+    query = """
+    query asyncUserResolve {
+        asyncUserResolve
+      }
+    """
+    if not gql_client.is_async:
+        return
+    user = UserFactory.create()
+    with gql_client.login(user):
+        res = gql_client.query(
+            query,
+            asserts_errors=False,
+        )
+        assert res.data is None
+        assert res.errors == [
+            {
+                "message": "You don't have permission to access this app.",
+                "locations": [{"line": 3, "column": 9}],
+                "path": ["asyncUserResolve"],
+            },
+        ]
+
+    superuser = SuperuserUserFactory.create()
+    with gql_client.login(superuser):
+        res = gql_client.query(query)
+        assert res.data == {"asyncUserResolve": True}
+    user_with_perm = UserFactory.create()
+    user_with_perm.user_permissions.add(
+        Permission.objects.get(codename="view_issue"),
+    )
+    with gql_client.login(user_with_perm):
+        res = gql_client.query(query)
+        assert res.data == {"asyncUserResolve": True}
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -222,7 +222,7 @@ def test_async_user_resolve(db, gql_client: GraphQLTestClient):
       }
     """
     if not gql_client.is_async:
-        return
+        pytest.skip("needs async client")
     user = UserFactory.create()
     with gql_client.login(user):
         res = gql_client.query(


### PR DESCRIPTION
The HasPerm extension  called in an async context get_current_user. This caused decorated async fields to crash

The test schema was updated for an example.

This PR fixes also a minor bug in another test: the query execution was missing

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
