### PR TITLE
fix: support for fields using async only extensions

### DIFF
--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -66,6 +66,16 @@ class StrawberryDjangoFieldBase(StrawberryField):
         return False
 
     @functools.cached_property
+    def is_async(self) -> bool:
+        # Our default resolver is sync by default but will return a coroutine
+        # when running ASGI. If we happen to have an extension that only supports
+        # async, make sure we mark the field as async as well to support resolving
+        # it properly.
+        return super().is_async or any(
+            e.supports_async and not e.supports_sync for e in self.extensions
+        )
+
+    @functools.cached_property
     def django_type(self) -> type[WithStrawberryDjangoObjectDefinition] | None:
         origin = self.type
 

--- a/tests/relay/test_fields.py
+++ b/tests/relay/test_fields.py
@@ -49,7 +49,6 @@ def test_query_node():
     }
 
 
-@pytest.mark.skip(reason="Async permissions not currently working...")
 async def test_query_node_with_async_permissions():
     result = await schema.execute(
         """


### PR DESCRIPTION
Fields using extensions that only support async resolution needs to be marked as `is_async = True`.

Fix #433
