### PR TITLE
Allow updates of nested fields

### DIFF
--- a/strawberry_django/auth/mutations.py
+++ b/strawberry_django/auth/mutations.py
@@ -89,6 +89,7 @@ class DjangoRegisterMutation(DjangoCreateMutation):
                 info,
                 model,
                 data,
+                key_attr=self.key_attr,
                 full_clean=self.full_clean,
                 pre_save_hook=lambda obj: obj.set_password(password),
             )

--- a/strawberry_django/mutations/fields.py
+++ b/strawberry_django/mutations/fields.py
@@ -233,13 +233,17 @@ class DjangoCreateMutation(DjangoMutationCUD, StrawberryDjangoFieldFilters):
         if self.is_list:
             assert isinstance(data, list)
             return [
-                self.create(resolvers.parse_input(info, vars(d)), info=info)
+                self.create(
+                    resolvers.parse_input(info, vars(d), self.key_attr), info=info
+                )
                 for d in data
             ]
 
         assert not isinstance(data, list)
         return self.create(
-            resolvers.parse_input(info, vars(data)) if data is not None else {},
+            resolvers.parse_input(info, vars(data), self.key_attr)
+            if data is not None
+            else {},
             info=info,
         )
 
@@ -253,6 +257,7 @@ class DjangoCreateMutation(DjangoMutationCUD, StrawberryDjangoFieldFilters):
                 info,
                 model,
                 data,
+                key_attr=self.key_attr,
                 full_clean=self.full_clean,
             )
 
@@ -306,7 +311,9 @@ class DjangoUpdateMutation(DjangoMutationCUD, StrawberryDjangoFieldFilters):
                 info,
             )
 
-        return self.update(info, instance, resolvers.parse_input(info, vdata))
+        return self.update(
+            info, instance, resolvers.parse_input(info, vdata, self.key_attr)
+        )
 
     def update(
         self,
@@ -320,6 +327,7 @@ class DjangoUpdateMutation(DjangoMutationCUD, StrawberryDjangoFieldFilters):
                 info,
                 instance,
                 data,
+                key_attr=self.key_attr,
                 full_clean=self.full_clean,
             )
 
@@ -365,7 +373,9 @@ class DjangoDeleteMutation(
                 info,
             )
 
-        return self.delete(info, instance, resolvers.parse_input(info, vdata))
+        return self.delete(
+            info, instance, resolvers.parse_input(info, vdata, self.key_attr)
+        )
 
     def delete(
         self,

--- a/strawberry_django/mutations/fields.py
+++ b/strawberry_django/mutations/fields.py
@@ -234,14 +234,15 @@ class DjangoCreateMutation(DjangoMutationCUD, StrawberryDjangoFieldFilters):
             assert isinstance(data, list)
             return [
                 self.create(
-                    resolvers.parse_input(info, vars(d), self.key_attr), info=info
+                    resolvers.parse_input(info, vars(d), key_attr=self.key_attr),
+                    info=info,
                 )
                 for d in data
             ]
 
         assert not isinstance(data, list)
         return self.create(
-            resolvers.parse_input(info, vars(data), self.key_attr)
+            resolvers.parse_input(info, vars(data), key_attr=self.key_attr)
             if data is not None
             else {},
             info=info,
@@ -312,7 +313,7 @@ class DjangoUpdateMutation(DjangoMutationCUD, StrawberryDjangoFieldFilters):
             )
 
         return self.update(
-            info, instance, resolvers.parse_input(info, vdata, self.key_attr)
+            info, instance, resolvers.parse_input(info, vdata, key_attr=self.key_attr)
         )
 
     def update(
@@ -374,7 +375,7 @@ class DjangoDeleteMutation(
             )
 
         return self.delete(
-            info, instance, resolvers.parse_input(info, vdata, self.key_attr)
+            info, instance, resolvers.parse_input(info, vdata, key_attr=self.key_attr)
         )
 
     def delete(

--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -72,8 +72,6 @@ def _parse_pk(
         if key_attr in value:
             obj_pk = value[key_attr]
             if obj_pk != strawberry.UNSET:
-                if key_attr == "id":
-                    obj_pk = int(obj_pk)
                 return model._default_manager.get(pk=obj_pk), value
         return None, value
 

--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -56,6 +56,7 @@ _M = TypeVar("_M", bound=Model)
 def _parse_pk(
     value: ParsedObject | strawberry.ID | _M | None,
     model: type[_M],
+    *,
     key_attr: str | None = "pk",
 ) -> tuple[_M | None, dict[str, Any] | None]:
     if value is None:
@@ -79,7 +80,9 @@ def _parse_pk(
     return model._default_manager.get(pk=value), None
 
 
-def _parse_data(info: Info, model: type[_M], value: Any, key_attr: str | None = "pk"):
+def _parse_data(
+    info: Info, model: type[_M], value: Any, *, key_attr: str | None = "pk"
+):
     obj, data = _parse_pk(value, model, key_attr)
     parsed_data = {}
     if data:
@@ -102,27 +105,27 @@ def _parse_data(info: Info, model: type[_M], value: Any, key_attr: str | None = 
 
 @overload
 def parse_input(
-    info: Info, data: dict[str, _T], key_attr: str | None = "pk"
+    info: Info, data: dict[str, _T], *, key_attr: str | None = "pk"
 ) -> dict[str, _T]: ...
 
 
 @overload
 def parse_input(
-    info: Info, data: list[_T], key_attr: str | None = "pk"
+    info: Info, data: list[_T], *, key_attr: str | None = "pk"
 ) -> list[_T]: ...
 
 
 @overload
 def parse_input(
-    info: Info, data: relay.GlobalID, key_attr: str | None = "pk"
+    info: Info, data: relay.GlobalID, *, key_attr: str | None = "pk"
 ) -> relay.Node: ...
 
 
 @overload
-def parse_input(info: Info, data: Any, key_attr: str | None = "pk") -> Any: ...
+def parse_input(info: Info, data: Any, *, key_attr: str | None = "pk") -> Any: ...
 
 
-def parse_input(info: Info, data: Any, key_attr: str | None = "pk"):
+def parse_input(info: Info, data: Any, *, key_attr: str | None = "pk"):
     if isinstance(data, dict):
         return {k: parse_input(info, v, key_attr) for k, v in data.items()}
 

--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -54,7 +54,9 @@ _M = TypeVar("_M", bound=Model)
 
 
 def _parse_pk(
-    value: ParsedObject | strawberry.ID | _M | None, model: type[_M], key_attr: str
+    value: ParsedObject | strawberry.ID | _M | None,
+    model: type[_M],
+    key_attr: str | None = "pk",
 ) -> tuple[_M | None, dict[str, Any] | None]:
     if value is None:
         return None, None
@@ -77,7 +79,7 @@ def _parse_pk(
     return model._default_manager.get(pk=value), None
 
 
-def _parse_data(info: Info, model: type[_M], value: Any, key_attr: str):
+def _parse_data(info: Info, model: type[_M], value: Any, key_attr: str | None = "pk"):
     obj, data = _parse_pk(value, model, key_attr)
     parsed_data = {}
     if data:
@@ -99,22 +101,28 @@ def _parse_data(info: Info, model: type[_M], value: Any, key_attr: str):
 
 
 @overload
-def parse_input(info: Info, data: dict[str, _T], key_attr: str) -> dict[str, _T]: ...
+def parse_input(
+    info: Info, data: dict[str, _T], key_attr: str | None = "pk"
+) -> dict[str, _T]: ...
 
 
 @overload
-def parse_input(info: Info, data: list[_T], key_attr: str) -> list[_T]: ...
+def parse_input(
+    info: Info, data: list[_T], key_attr: str | None = "pk"
+) -> list[_T]: ...
 
 
 @overload
-def parse_input(info: Info, data: relay.GlobalID, key_attr: str) -> relay.Node: ...
+def parse_input(
+    info: Info, data: relay.GlobalID, key_attr: str | None = "pk"
+) -> relay.Node: ...
 
 
 @overload
-def parse_input(info: Info, data: Any, key_attr: str) -> Any: ...
+def parse_input(info: Info, data: Any, key_attr: str | None = "pk") -> Any: ...
 
 
-def parse_input(info: Info, data: Any, key_attr: str):
+def parse_input(info: Info, data: Any, key_attr: str | None = "pk"):
     if isinstance(data, dict):
         return {k: parse_input(info, v, key_attr) for k, v in data.items()}
 
@@ -170,7 +178,7 @@ def prepare_create_update(
     info: Info,
     instance: Model,
     data: dict[str, Any],
-    key_attr: str,
+    key_attr: str | None = "pk",
     full_clean: bool | FullCleanOptions = True,
 ) -> tuple[
     Model,
@@ -261,7 +269,7 @@ def create(
     model: type[_M],
     data: dict[str, Any],
     *,
-    key_attr: str,
+    key_attr: str | None = "pk",
     full_clean: bool | FullCleanOptions = True,
     pre_save_hook: Callable[[_M], None] | None = None,
 ) -> _M: ...
@@ -273,7 +281,7 @@ def create(
     model: type[_M],
     data: list[dict[str, Any]],
     *,
-    key_attr: str,
+    key_attr: str | None = "pk",
     full_clean: bool | FullCleanOptions = True,
     pre_save_hook: Callable[[_M], None] | None = None,
 ) -> list[_M]: ...
@@ -285,7 +293,7 @@ def create(
     model: type[_M],
     data: dict[str, Any] | list[dict[str, Any]],
     *,
-    key_attr: str,
+    key_attr: str | None = "pk",
     full_clean: bool | FullCleanOptions = True,
     pre_save_hook: Callable[[_M], None] | None = None,
 ):
@@ -350,7 +358,7 @@ def update(
     instance: _M,
     data: dict[str, Any],
     *,
-    key_attr: str,
+    key_attr: str | None = "pk",
     full_clean: bool | FullCleanOptions = True,
     pre_save_hook: Callable[[_M], None] | None = None,
 ) -> _M: ...
@@ -362,7 +370,7 @@ def update(
     instance: Iterable[_M],
     data: dict[str, Any],
     *,
-    key_attr: str,
+    key_attr: str | None = "pk",
     full_clean: bool | FullCleanOptions = True,
     pre_save_hook: Callable[[_M], None] | None = None,
 ) -> list[_M]: ...
@@ -374,7 +382,7 @@ def update(
     instance: _M | Iterable[_M],
     data: dict[str, Any],
     *,
-    key_attr: str,
+    key_attr: str | None = "pk",
     full_clean: bool | FullCleanOptions = True,
     pre_save_hook: Callable[[_M], None] | None = None,
 ) -> _M | list[_M]:
@@ -491,7 +499,7 @@ def update_m2m(
     instance: Model,
     field: ManyToManyField | ForeignObjectRel,
     value: Any,
-    key_attr: str,
+    key_attr: str | None = "pk",
     full_clean: bool | FullCleanOptions = True,
 ):
     if value is UNSET:

--- a/tests/mutations/conftest.py
+++ b/tests/mutations/conftest.py
@@ -34,8 +34,7 @@ class Mutation:
     create_fruit: Fruit = mutations.create(FruitInput)
     create_fruits: List[Fruit] = mutations.create(FruitInput)
     update_fruits: List[Fruit] = mutations.update(
-        FruitPartialInput,
-        filters=FruitFilter,
+        FruitPartialInput, filters=FruitFilter, key_attr="id"
     )
 
     @strawberry_django.mutation
@@ -46,10 +45,8 @@ class Mutation:
             resolvers.update(
                 info,
                 fruit,
-                resolvers.parse_input(
-                    info,
-                    vars(data),
-                ),
+                resolvers.parse_input(info, vars(data), key_attr="id"),
+                key_attr="id",
             ),
         )
 

--- a/tests/mutations/test_mutations.py
+++ b/tests/mutations/test_mutations.py
@@ -66,6 +66,37 @@ def test_update_m2m_with_validation_error(mutation, fruit):
     assert result.errors[0].message == "{'name': ['We do not allow rotten fruits.']}"
 
 
+def test_update_m2m_with_new_different_objects(mutation, fruit):
+    result = mutation(
+        '{ fruits: updateFruits(data: { types: [{name: "apple"}, {name: "strawberry"}]}) { id types { id name }}}'
+    )
+    assert not result.errors
+    assert result.data["fruits"][0]["types"] == [
+        {"id": "1", "name": "apple"},
+        {"id": "2", "name": "strawberry"},
+    ]
+
+    result = mutation(
+        '{ fruits: updateFruits(data: { types: [{id: "1", name: "apple updated"}, {name: "raspberry"}]}) { id types { id name }}}'
+    )
+
+    assert result.data["fruits"][0]["types"] == [
+        {"id": "1", "name": "apple updated"},
+        {"id": "3", "name": "raspberry"},
+    ]
+
+
+def test_update_m2m_with_duplicates(mutation, fruit):
+    result = mutation(
+        '{ fruits: updateFruits(data: { types: [{name: "apple"}, {name: "apple"}]}) { id types { id name }}}'
+    )
+    assert not result.errors
+    assert result.data["fruits"][0]["types"] == [
+        {"id": "1", "name": "apple"},
+        {"id": "2", "name": "apple"},
+    ]
+
+
 def test_update_lazy_object(mutation, fruit):
     result = mutation(
         '{ fruit: updateLazyFruit(data: { name: "orange" }) { id name } }',

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -498,6 +498,7 @@ class Mutation:
                 Quiz,
                 {"title": title},
                 full_clean={"exclude": ["sequence"]} if full_clean_options else True,
+                key_attr="id",
             ),
         )
 


### PR DESCRIPTION
# Summary

This PR allows updates of nested fields, i.e.

- update the field by setting the ID
- add copies of Child by leaving the ID unset
- remove a Child by omitting it

## Description

The `update_m2m`, `parse_data` and the `_parse_pk` methods were changed.  `_parse_pk` does now return the id as well. If `parse_data` finds an UNSET id, the id is still returned. The id is used to check if a new object is to be created or not. If we have an Input type, the ID is not part of the `data`-dict. This means, we perform a `get_or_create`.

Since `key_attr` can be used to change the primary key from `id` to an "arbitrary" value, major API changes had to be made. This was proposed in https://github.com/strawberry-graphql/strawberry-graphql-django/issues/383.

I am not sure, if this leads to breaking changes - a couple of methods were affected.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

https://github.com/strawberry-graphql/strawberry-graphql-django/issues/383

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
