### PR TITLE
feat(optimizer): Do not defer select_related fields if no only was specified

### DIFF
--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -197,6 +197,14 @@ class IssueType(relay.Node):
         strawberry_django.connection()
     )
 
+    @strawberry_django.field(select_related="milestone", only="milestone__name")
+    def milestone_name(self) -> str:
+        return self.milestone.name
+
+    @strawberry_django.field(select_related="milestone")
+    def milestone_name_without_only_optimization(self) -> str:
+        return self.milestone.name
+
 
 @strawberry_django.type(Tag)
 class TagType(relay.Node):

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -256,6 +256,8 @@ type IssueType implements Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): FavoriteTypeConnection!
+  milestoneName: String!
+  milestoneNameWithoutOnlyOptimization: String!
 }
 
 """A connection to a list of items."""


### PR DESCRIPTION
When doing `select_related=["foo"]` and not doing `only=["foo_<something>"]`, we should add
`"foo"` to the only field to make sure none of its fields will be deferred.

Fix #455
